### PR TITLE
youngseok, hotfix: createdAt, updatedAt반환값을 db와 동일하게 수정 #12

### DIFF
--- a/src/main/java/com/househub/backend/domain/customer/dto/CustomerReqDto.java
+++ b/src/main/java/com/househub/backend/domain/customer/dto/CustomerReqDto.java
@@ -33,8 +33,9 @@ public class CustomerReqDto {
                 .email(entity.getEmail())
                 .memo(entity.getMemo())
                 .gender(entity.getGender())
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .deletedAt(entity.getDeletedAt())
                 .build();
     }
 

--- a/src/main/java/com/househub/backend/domain/customer/dto/CustomerResDto.java
+++ b/src/main/java/com/househub/backend/domain/customer/dto/CustomerResDto.java
@@ -33,8 +33,9 @@ public class CustomerResDto {
                 .email(entity.getEmail())
                 .memo(entity.getMemo())
                 .gender(entity.getGender())
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .deletedAt(entity.getDeletedAt())
                 .build();
     }
 


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 여러명의 회원을 등록 후, 전체 반환 데이터를 보면 생성일시와 수정일시가 현재 시간과 동일하게 출력되는 문제

## ✏️ 변경 사항
- 반환되는 결과인 CustomerResDto 의 toDto 메소드를 수정
- createdAt과 updatedAt을 entity의 속성값으로 수정

## 📸 스크린샷 (선택사항)
- 
![image](https://github.com/user-attachments/assets/987c3ab7-75ed-4733-ba08-34bc493eae27)


## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [x] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #12
