### PR TITLE
공인중개사 회원가입 API 구현 및 유닛 테스트 작성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,13 +3,14 @@ name: Backend CI/CD
 on:
   push:
     branches:
+      - main
       - develop
   pull_request:
     branches:
       - develop
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -66,22 +67,40 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew -i clean build --no-daemon
 
-      # 7. Docker 이미지 빌드
+      # 빌드 결과 캐싱 (선택 사항)
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build # build 작업이 성공해야 deploy 작업 실행
+    if: github.ref == 'refs/heads/main' # main 브랜치로 push 될 때만 실행
+
+    steps:
+      # 1. GitHub 저장소에서 코드 체크아웃
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2. Docker 이미지 빌드
       - name: Build Docker image
         run: docker build -f Dockerfile -t ${{ secrets.DOCKERHUB_REPO }}:latest .
 
-      # 8. Docker Hub 로그인
+      # 3. Docker Hub 로그인
       - name: DockerHub login
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 9. Docker Hub에 이미지 푸시
+      # 4. Docker Hub에 이미지 푸시
       - name: Push Docker image
         run: docker push ${{ secrets.DOCKERHUB_REPO }}:latest
 
-      # 10. Connect to EC2 and Deploy
+      # 5. Connect to EC2 and Deploy
       - name: Connect to EC2 and Deploy
         uses: appleboy/ssh-action@master
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'jakarta.validation:jakarta.validation-api'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation("org.springframework.security:spring-security-test")
+	testImplementation 'org.mockito:mockito-junit-jupiter'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
@@ -23,7 +23,7 @@ public class WebSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable) // REST API 서버이므로 CSRF 비활성화
                 .authorizeHttpRequests((authz) -> authz
                         .requestMatchers("/api/**").permitAll() // /api/** 경로에 대한 모든 접근 허용
-//                        .anyRequest().authenticated() // 나머지 요청은 인증 필요
+                        .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 명시적으로 세션 생성 정책 설정

--- a/src/main/java/com/househub/backend/common/exception/AlreadyExistsException.java
+++ b/src/main/java/com/househub/backend/common/exception/AlreadyExistsException.java
@@ -1,0 +1,26 @@
+package com.househub.backend.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * {
+ *     "status": false,
+ *     "message": input_message,
+ *     "code": input_code,
+ *     "errors": null,
+ *     "data": null
+ * }
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+@Getter
+public class AlreadyExistsException extends RuntimeException {
+    private final String code;
+
+    public AlreadyExistsException(String message, String code) {
+        super(message);
+        this.code = code;
+    }
+
+}

--- a/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
@@ -25,9 +25,20 @@ public class GlobalExceptionHandler {
                 .message("입력값을 확인해주세요.")
                 .code("VALIDATION_ERROR")
                 .errors(fieldErrors)
-                .data(null)
                 .build();
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(AlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleAlreadyExistsException(AlreadyExistsException ex) {
+        ErrorResponse response = ErrorResponse.builder()
+                .success(false)
+                .message(ex.getMessage())
+                .code(ex.getCode())
+                .errors(null)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 }

--- a/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.househub.backend.common.exception;
+
+import com.househub.backend.common.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 유효성 검사 실패 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        List<ErrorResponse.FieldError> fieldErrors = ex.getFieldErrors().stream()
+                .map(fieldError -> ErrorResponse.FieldError.builder().field(fieldError.getField()).message(fieldError.getDefaultMessage()).build())
+                .collect(Collectors.toList());
+
+        ErrorResponse response = ErrorResponse.builder()
+                .success(false)
+                .message("입력값을 확인해주세요.")
+                .code("VALIDATION_ERROR")
+                .errors(fieldErrors)
+                .data(null)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+}

--- a/src/main/java/com/househub/backend/common/response/ErrorResponse.java
+++ b/src/main/java/com/househub/backend/common/response/ErrorResponse.java
@@ -13,7 +13,6 @@ public class ErrorResponse {
     private final String message;
     private final String code;
     private final List<FieldError> errors;
-    private final Object data;
 
     @Getter
     @Builder

--- a/src/main/java/com/househub/backend/common/response/ErrorResponse.java
+++ b/src/main/java/com/househub/backend/common/response/ErrorResponse.java
@@ -1,0 +1,24 @@
+package com.househub.backend.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final boolean success;
+    private final String message;
+    private final String code;
+    private final List<FieldError> errors;
+    private final Object data;
+
+    @Getter
+    @Builder
+    public static class FieldError {
+        private final String field;
+        private final String message;
+    }
+}

--- a/src/main/java/com/househub/backend/common/response/SuccessResponse.java
+++ b/src/main/java/com/househub/backend/common/response/SuccessResponse.java
@@ -1,0 +1,22 @@
+package com.househub.backend.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SuccessResponse<T> {
+    private boolean success;
+    private String message;
+    private String code;
+    private T data;
+
+    public static <T> SuccessResponse<T> success(String message, String code, T data) {
+        return SuccessResponse.<T>builder()
+                .success(true)
+                .message(message)
+                .code(code)
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/househub/backend/domain/agent/controller/AgentController.java
+++ b/src/main/java/com/househub/backend/domain/agent/controller/AgentController.java
@@ -1,12 +1,12 @@
-package com.househub.backend.domain.member.controller;
+package com.househub.backend.domain.agent.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/members")
-public class MemberController {
+@RequestMapping("/api/agents")
+public class AgentController {
     @GetMapping("")
     public String hello() {
         return "Hello, World!";

--- a/src/main/java/com/househub/backend/domain/agent/entity/Agent.java
+++ b/src/main/java/com/househub/backend/domain/agent/entity/Agent.java
@@ -1,0 +1,86 @@
+package com.househub.backend.domain.agent.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+@Entity
+@Table(name = "agents")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Agent implements UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, length = 50)
+    private String contact;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String licenseNumber;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AgentStatus status; // PENDING(가입 대기중), ACTIVE(활성화), INACTIVE(비활성화), DELETED(탈퇴), BLOCKED(차단)
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column
+    private LocalDateTime updatedAt;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "real_estate_id")
+    private RealEstate realEstate;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+        this.status = AgentStatus.PENDING;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // Agent 의 Role 을 기반으로 접근 제어 설정하기 위해 필요
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.getValue()));
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/src/main/java/com/househub/backend/domain/agent/entity/AgentStatus.java
+++ b/src/main/java/com/househub/backend/domain/agent/entity/AgentStatus.java
@@ -1,0 +1,5 @@
+package com.househub.backend.domain.agent.entity;
+
+public enum AgentStatus {
+    PENDING, APPROVED, REJECTED
+}

--- a/src/main/java/com/househub/backend/domain/agent/entity/RealEstate.java
+++ b/src/main/java/com/househub/backend/domain/agent/entity/RealEstate.java
@@ -1,0 +1,57 @@
+package com.househub.backend.domain.agent.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "real_estates")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RealEstate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String businessRegistrationNumber;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = false, length = 50)
+    private String contact;
+
+    @Column(nullable = false)
+    private String roadAddress;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column
+    private LocalDateTime updatedAt;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/househub/backend/domain/agent/entity/Role.java
+++ b/src/main/java/com/househub/backend/domain/agent/entity/Role.java
@@ -1,0 +1,16 @@
+package com.househub.backend.domain.agent.entity;
+
+public enum Role {
+    AGENT("ROLE_AGENT"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String value;
+
+    Role(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/househub/backend/domain/agent/repository/AgentRepository.java
+++ b/src/main/java/com/househub/backend/domain/agent/repository/AgentRepository.java
@@ -1,0 +1,10 @@
+package com.househub.backend.domain.agent.repository;
+
+import com.househub.backend.domain.agent.entity.Agent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AgentRepository extends JpaRepository<Agent, Long> {
+    Optional<Agent> findByLicenseNumber(String licenseNumber);
+}

--- a/src/main/java/com/househub/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/househub/backend/domain/auth/controller/AuthController.java
@@ -1,8 +1,12 @@
 package com.househub.backend.domain.auth.controller;
 
-import com.househub.backend.domain.auth.dto.SignUpRequest;
+import com.househub.backend.common.response.SuccessResponse;
+import com.househub.backend.domain.auth.dto.SignUpRequestDto;
+import com.househub.backend.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,11 +15,17 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
+    private final AuthService authService;
+
     @PostMapping("/signup")
-    public String signup(@Valid @RequestBody SignUpRequest request) {
+    public ResponseEntity<SuccessResponse<Void>> signup(@Valid @RequestBody SignUpRequestDto request) {
         log.info("{}", request.getAgent());
         log.info("{}", request.getRealEstate());
-        return "부동산 공인중개사 회원가입";
+
+        authService.signup(request);
+
+        return ResponseEntity.ok(SuccessResponse.success("회원가입 신청이 완료되었습니다. 관리자 승인까지 시간이 소요될 수 있습니다.", "SIGNUP_SUCCESS", null));
     }
 }

--- a/src/main/java/com/househub/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/househub/backend/domain/auth/controller/AuthController.java
@@ -1,0 +1,21 @@
+package com.househub.backend.domain.auth.controller;
+
+import com.househub.backend.domain.auth.dto.SignUpRequest;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    @PostMapping("/signup")
+    public String signup(@Valid @RequestBody SignUpRequest request) {
+        log.info("{}", request.getAgent());
+        log.info("{}", request.getRealEstate());
+        return "부동산 공인중개사 회원가입";
+    }
+}

--- a/src/main/java/com/househub/backend/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/SignUpRequest.java
@@ -1,0 +1,104 @@
+package com.househub.backend.domain.auth.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpRequest {
+
+    @Valid
+    private AgentDTO agent;
+
+    @Valid
+    private RealEstateDTO realEstate;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AgentDTO {
+        @NotBlank(message = "이름을 입력하세요.")
+        private String name;
+
+        @NotBlank(message = "자격증 번호를 입력해주세요.")
+        @Pattern(regexp = "^(서울|부산|대구|인천|광주|대전|울산|세종|경기|강원|충북|충남|전북|전남|경북|경남|제주)-(\\d{4})-(\\d{5})$", message = "잘못된 자격증 번호 형식입니다. (예: 123-45-67890)")
+        private String licenseNumber;
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "잘못된 이메일 형식입니다.")
+        private String email;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$", message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
+        private String password;
+
+        @NotBlank(message = "연락처를 입력해주세요.")
+        @Pattern(regexp = "\\d{3}-\\d{4}-\\d{4}", message = "잘못된 연락처 형식입니다. (예: 010-1234-5678)")
+        private String contact;
+
+        @Override
+        public String toString() {
+            return "AgentDTO{" +
+                    "name='" + name + '\'' +
+                    ", licenseNumber='" + licenseNumber + '\'' +
+                    ", email='" + email + '\'' +
+                    ", password='" + password + '\'' +
+                    ", contact='" + contact + '\'' +
+                    '}';
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RealEstateDTO {
+        @NotBlank(message = "부동산 이름을 입력해주세요.")
+        private String name;
+
+        @NotBlank(message = "사업자등록번호를 입력해주세요.")
+        @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "잘못된 자격증 번호 형식입니다. (예: 123-45-67890)")
+        private String businessRegistrationNumber;
+
+        @NotBlank(message = "지번 주소를 입력해주세요.")
+        private String address;
+
+        @NotBlank(message = "도로명 주소를 입력해주세요.")
+        private String roadAddress;
+
+        @NotBlank(message = "연락처를 입력해주세요.")
+        @Pattern(regexp = "\\d{2,3}-\\d{3,4}-\\d{4}", message = "잘못된 연락처 형식입니다. (예: 02-1234-5678)")
+        private String contact;
+
+        @Override
+        public String toString() {
+            return "RealEstateDTO{" +
+                    "name='" + name + '\'' +
+                    ", businessRegistrationNumber='" + businessRegistrationNumber + '\'' +
+                    ", address='" + address + '\'' +
+                    ", roadAddress='" + roadAddress + '\'' +
+                    ", contact='" + contact + '\'' +
+                    '}';
+        }
+
+    }
+
+    @Override
+    public String toString() {
+        return "SignUpRequest{" +
+                "agent=" + agent +
+                ", realEstate=" + realEstate +
+                '}';
+    }
+}

--- a/src/main/java/com/househub/backend/domain/auth/dto/SignUpRequestDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/SignUpRequestDto.java
@@ -1,5 +1,7 @@
 package com.househub.backend.domain.auth.dto;
 
+import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.agent.entity.RealEstate;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -14,19 +16,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class SignUpRequest {
+public class SignUpRequestDto {
 
     @Valid
-    private AgentDTO agent;
+    private AgentDto agent;
 
     @Valid
-    private RealEstateDTO realEstate;
+    private RealEstateDto realEstate;
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class AgentDTO {
+    public static class AgentDto {
         @NotBlank(message = "이름을 입력하세요.")
         private String name;
 
@@ -47,6 +49,17 @@ public class SignUpRequest {
         @Pattern(regexp = "\\d{3}-\\d{4}-\\d{4}", message = "잘못된 연락처 형식입니다. (예: 010-1234-5678)")
         private String contact;
 
+        public Agent toAgentEntity(RealEstate realEstate) {
+            return Agent.builder()
+                    .name(name)
+                    .licenseNumber(licenseNumber)
+                    .email(email)
+                    .password(password)
+                    .contact(contact)
+                    .realEstate(realEstate)
+                    .build();
+        }
+
         @Override
         public String toString() {
             return "AgentDTO{" +
@@ -63,7 +76,7 @@ public class SignUpRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class RealEstateDTO {
+    public static class RealEstateDto {
         @NotBlank(message = "부동산 이름을 입력해주세요.")
         private String name;
 
@@ -92,6 +105,15 @@ public class SignUpRequest {
                     '}';
         }
 
+        public RealEstate toRealEstateEntity() {
+            return RealEstate.builder()
+                    .name(name)
+                    .businessRegistrationNumber(businessRegistrationNumber)
+                    .address(address)
+                    .roadAddress(roadAddress)
+                    .contact(contact)
+                    .build();
+        }
     }
 
     @Override

--- a/src/main/java/com/househub/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/househub/backend/domain/auth/service/AuthService.java
@@ -1,0 +1,7 @@
+package com.househub.backend.domain.auth.service;
+
+import com.househub.backend.domain.auth.dto.SignUpRequestDto;
+
+public interface AuthService {
+    public void signup(SignUpRequestDto request);
+}

--- a/src/main/java/com/househub/backend/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/auth/service/impl/AuthServiceImpl.java
@@ -1,0 +1,114 @@
+package com.househub.backend.domain.auth.service.impl;
+
+import com.househub.backend.common.exception.AlreadyExistsException;
+import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.agent.entity.AgentStatus;
+import com.househub.backend.domain.agent.entity.RealEstate;
+import com.househub.backend.domain.agent.entity.Role;
+import com.househub.backend.domain.agent.repository.AgentRepository;
+import com.househub.backend.domain.auth.dto.SignUpRequestDto;
+import com.househub.backend.domain.auth.service.AuthService;
+import com.househub.backend.domain.realEstate.repository.RealEstateRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private final AgentRepository agentRepository;
+    private final RealEstateRepository realEstateRepository;
+
+
+    /**
+     * 부동산 공인중개사 회원가입
+     *
+     * @param request 회원가입 요청 정보
+     */
+    @Transactional
+    @Override
+    public void signup(SignUpRequestDto request) {
+        // 중개사의 자격증 번호 이미 존재하는지 확인
+        validateLicenseNumber(request.getAgent().getLicenseNumber());
+
+        // 부동산 사업자 등록 번호 이미 존재하는지 확인
+        // 존재하지 않으면 부동산 정보 새로 저장
+        RealEstate realEstate = getOrCreateRealEstate(request.getRealEstate());
+
+        // 증개사 정보 저장
+        saveAgent(request.getAgent(), realEstate);
+    }
+
+    /**
+     * 자격증 번호의 중복 여부를 검증합니다.
+     *
+     * @param licenseNumber 검증할 자격증 번호
+     * @throws AlreadyExistsException 자격증 번호가 이미 존재하는 경우 발생
+     */
+    private void validateLicenseNumber(String licenseNumber) {
+        agentRepository.findByLicenseNumber(licenseNumber)
+                .ifPresent(agent -> {
+                    log.error("이미 존재하는 자격증 번호: {}", agent.getLicenseNumber());
+                    throw new AlreadyExistsException("이미 존재하는 자격증 번호입니다.", "LICENSE_NUMBER_ALREADY_EXISTS");
+                });
+    }
+
+    /**
+     * 부동산 사업자 등록 번호의 존재 여부를 확인하고, 존재하지 않으면 새로운 부동산 정보를 저장합니다.
+     *
+     * @param realEstateDto 부동산 정보 DTO
+     * @return 저장된 또는 존재하는 부동산 엔티티
+     */
+    private RealEstate getOrCreateRealEstate(SignUpRequestDto.RealEstateDto realEstateDto) {
+        return realEstateRepository.findByBusinessRegistrationNumber(realEstateDto.getBusinessRegistrationNumber())
+                .orElseGet(() -> realEstateRepository.save(toRealEstateEntity(realEstateDto)));
+    }
+
+    /**
+     * 공인중개사 정보를 저장합니다.
+     *
+     * @param agentDto 공인중개사 정보 DTO
+     * @param realEstate 부동산 엔티티
+     */
+    private void saveAgent(SignUpRequestDto.AgentDto agentDto, RealEstate realEstate) {
+        agentRepository.save(toAgentEntity(agentDto, realEstate));
+    }
+
+    /**
+     * RequestDto 의 부동산 정보를 RealEstate 엔티티로 변환합니다.
+     *
+     * @param realEstateDTO 부동산 정보 DTO
+     * @return RealEstate 엔티티
+     */
+    private RealEstate toRealEstateEntity(SignUpRequestDto.RealEstateDto realEstateDTO) {
+        return RealEstate.builder()
+                .name(realEstateDTO.getName())
+                .businessRegistrationNumber(realEstateDTO.getBusinessRegistrationNumber())
+                .address(realEstateDTO.getAddress())
+                .roadAddress(realEstateDTO.getRoadAddress())
+                .contact(realEstateDTO.getContact())
+                .build();
+    }
+
+    /**
+     * RequestDto 의 공인중개사 정보를 Agent 엔티티로 변환합니다.
+     *
+     * @param agentDTO 공인중개사 정보 DTO
+     * @param realEstate 부동산 엔티티
+     * @return Agent 엔티티
+     */
+    private Agent toAgentEntity(SignUpRequestDto.AgentDto agentDTO, RealEstate realEstate) {
+        return Agent.builder()
+                .name(agentDTO.getName())
+                .licenseNumber(agentDTO.getLicenseNumber())
+                .email(agentDTO.getEmail())
+                .password(agentDTO.getPassword())
+                .contact(agentDTO.getContact())
+                .realEstate(realEstate)
+                .role(Role.AGENT)
+                .status(AgentStatus.PENDING)
+                .build();
+    }
+}

--- a/src/main/java/com/househub/backend/domain/realEstate/repository/RealEstateRepository.java
+++ b/src/main/java/com/househub/backend/domain/realEstate/repository/RealEstateRepository.java
@@ -1,0 +1,10 @@
+package com.househub.backend.domain.realEstate.repository;
+
+import com.househub.backend.domain.agent.entity.RealEstate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RealEstateRepository extends JpaRepository<RealEstate, Long> {
+    Optional<RealEstate> findByBusinessRegistrationNumber(String businessRegistrationNumber);
+}

--- a/src/test/java/com/househub/backend/controller/AuthControllerTest.java
+++ b/src/test/java/com/househub/backend/controller/AuthControllerTest.java
@@ -1,0 +1,76 @@
+package com.househub.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.househub.backend.common.config.WebSecurityConfig;
+import com.househub.backend.domain.auth.controller.AuthController;
+import com.househub.backend.domain.auth.dto.SignUpRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import(WebSecurityConfig.class)
+public class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 회원가입_실패_AgentDTO_유효성_검사() throws Exception {
+        SignUpRequest request = SignUpRequest.builder()
+                .agent(SignUpRequest.AgentDTO.builder()
+                        .name("") // 이름 누락
+                        .licenseNumber("잘못된 자격증 번호")
+                        .email("잘못된 이메일 번호")
+                        .password("1234") // 짧은 비밀번호
+                        .contact("잘못된 연락처")
+                        .build())
+                .realEstate(SignUpRequest.RealEstateDTO.builder()
+                        .name("테스트 부동산")
+                        .businessRegistrationNumber("123-45-67890")
+                        .address("테스트 주소")
+                        .roadAddress("테스트 도로명 주소")
+                        .contact("02-1234-5678")
+                        .build())
+                .build();
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/signup")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    void 회원가입_실패_RealEstateDTO_유효성_검사() throws Exception {
+        SignUpRequest request = SignUpRequest.builder()
+                .agent(SignUpRequest.AgentDTO.builder()
+                        .name("테스트 에이전트")
+                        .licenseNumber("서울-2023-12345")
+                        .email("test@example.com")
+                        .password("password123!")
+                        .contact("010-1234-5678")
+                        .build())
+                .realEstate(SignUpRequest.RealEstateDTO.builder()
+                        .name("") // 부동산 이름 누락
+                        .businessRegistrationNumber("잘못된 사업자등록번호")
+                        .address("") // 지번 주소 누락
+                        .roadAddress("") // 도로명 주소 누락
+                        .contact("잘못된 연락처")
+                        .build())
+                .build();
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+}

--- a/src/test/java/com/househub/backend/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/househub/backend/domain/auth/controller/AuthControllerTest.java
@@ -1,9 +1,8 @@
-package com.househub.backend.controller;
+package com.househub.backend.domain.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.househub.backend.common.config.WebSecurityConfig;
-import com.househub.backend.domain.auth.controller.AuthController;
-import com.househub.backend.domain.auth.dto.SignUpRequest;
+import com.househub.backend.domain.auth.dto.SignUpRequestDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -25,15 +24,15 @@ public class AuthControllerTest {
 
     @Test
     void 회원가입_실패_AgentDTO_유효성_검사() throws Exception {
-        SignUpRequest request = SignUpRequest.builder()
-                .agent(SignUpRequest.AgentDTO.builder()
+        SignUpRequestDto request = SignUpRequestDto.builder()
+                .agent(SignUpRequestDto.AgentDto.builder()
                         .name("") // 이름 누락
                         .licenseNumber("잘못된 자격증 번호")
                         .email("잘못된 이메일 번호")
                         .password("1234") // 짧은 비밀번호
                         .contact("잘못된 연락처")
                         .build())
-                .realEstate(SignUpRequest.RealEstateDTO.builder()
+                .realEstate(SignUpRequestDto.RealEstateDto.builder()
                         .name("테스트 부동산")
                         .businessRegistrationNumber("123-45-67890")
                         .address("테스트 주소")
@@ -51,15 +50,15 @@ public class AuthControllerTest {
     @Test
     @WithMockUser
     void 회원가입_실패_RealEstateDTO_유효성_검사() throws Exception {
-        SignUpRequest request = SignUpRequest.builder()
-                .agent(SignUpRequest.AgentDTO.builder()
+        SignUpRequestDto request = SignUpRequestDto.builder()
+                .agent(SignUpRequestDto.AgentDto.builder()
                         .name("테스트 에이전트")
                         .licenseNumber("서울-2023-12345")
                         .email("test@example.com")
                         .password("password123!")
                         .contact("010-1234-5678")
                         .build())
-                .realEstate(SignUpRequest.RealEstateDTO.builder()
+                .realEstate(SignUpRequestDto.RealEstateDto.builder()
                         .name("") // 부동산 이름 누락
                         .businessRegistrationNumber("잘못된 사업자등록번호")
                         .address("") // 지번 주소 누락

--- a/src/test/java/com/househub/backend/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/househub/backend/domain/auth/controller/AuthControllerTest.java
@@ -3,11 +3,13 @@ package com.househub.backend.domain.auth.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.househub.backend.common.config.WebSecurityConfig;
 import com.househub.backend.domain.auth.dto.SignUpRequestDto;
+import com.househub.backend.domain.auth.service.AuthService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -16,6 +18,9 @@ import org.springframework.security.test.context.support.WithMockUser;
 @WebMvcTest(controllers = AuthController.class)
 @Import(WebSecurityConfig.class)
 public class AuthControllerTest {
+
+    @MockitoBean
+    private AuthService authService;
     @Autowired
     private MockMvc mockMvc;
 


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 부동산 공인중개사 회원가입 API 및 유닛 테스트를 구현했습니다. 이 PR은 중개사 회원가입 기능을 추가하고, 해당 기능의 안정성을 확보하기 위한 유닛 테스트 코드를 포함합니다.
## ✏️ 변경 사항
- 회원가입 API 구현:
  - SignUpRequestDto를 통해 회원가입 요청을 받아, 중개사 및 부동산 정보를 저장하는 API를 구현했습니다.
  - 자격증 번호 및 사업자 등록 번호 중복 검증 로직을 추가하여 중복 가입을 방지했습니다.
  - 성공적인 회원가입 시, 성공 응답을 반환하도록 구현했습니다.
- 유닛 테스트 작성:
  - AuthServiceImpl의 각 메서드에 대한 유닛 테스트 코드를 작성했습니다.
  - 회원가입 성공 및 실패 시나리오를 테스트하여 기능의 안정성을 검증했습니다.
  - Mockito를 사용하여 레포지토리 및 로깅 객체를 모킹하여 테스트의 격리성을 확보했습니다.
  - 테스트 코드의 가독성을 높이기 위해 각 테스트 메서드에 주석을 추가했습니다.

## 📸 스크린샷
공인중개사 자격증 번호 중복된 경우, 
![Screenshot 2025-03-24 at 2 41 27 PM](https://github.com/user-attachments/assets/5aa81807-5efc-44f6-90f8-c78c0ba89839)
회원가입 성공한 경우,
![Screenshot 2025-03-24 at 2 43 09 PM](https://github.com/user-attachments/assets/7a43e6a8-aa09-401d-abc1-e767b77a01f2)

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #15 
- #22 
