### PR TITLE
byungchan, feature: 공인중개사 인증 관련 API 구현 및 수정(회원가입, 로그인, 세션 조회, 내 정보 조회)

### DIFF
--- a/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
@@ -42,6 +42,7 @@ public class WebSecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.authorizeHttpRequests((authz) -> authz
 				.requestMatchers(
 					"/api/auth/signup",

--- a/src/main/java/com/househub/backend/common/util/SessionManager.java
+++ b/src/main/java/com/househub/backend/common/util/SessionManager.java
@@ -1,6 +1,10 @@
 package com.househub.backend.common.util;
 
-import jakarta.servlet.http.HttpSession;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -9,28 +13,36 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import jakarta.servlet.http.HttpSession;
+
 // 세션 관리 담당
 @Component
 public class SessionManager {
-    public void manageAgentSession(Authentication authentication) {
-        // 보안 컨텍스트 설정
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+	public void manageAgentSession(Authentication authentication) {
+		// 보안 컨텍스트 설정
+		SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        // 세션 관리 로직
-        HttpSession session = getCurrentSession();
-        SecurityContext securityContext = SecurityContextHolder.getContext();
+		// 세션 관리 로직
+		HttpSession session = getCurrentSession();
+		SecurityContext securityContext = SecurityContextHolder.getContext();
 
-        // 세션 발급
-        session.setAttribute(
-                HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
-                securityContext
-        );
-        session.setMaxInactiveInterval(3600); // 1시간
-    }
+		// 세션 발급
+		session.setAttribute(
+			HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+			securityContext
+		);
+		session.setMaxInactiveInterval(3600); // 1시간
+	}
 
-    private HttpSession getCurrentSession() {
-        ServletRequestAttributes attributes =
-                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        return attributes.getRequest().getSession(true);
-    }
+	private HttpSession getCurrentSession() {
+		ServletRequestAttributes attributes =
+			(ServletRequestAttributes)RequestContextHolder.getRequestAttributes();
+		return attributes.getRequest().getSession(true);
+	}
+
+	public static String getSessionExpirationTime(int maxInactiveInterval) {
+		LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(maxInactiveInterval);
+		ZonedDateTime zonedDateTime = expiresAt.atZone(ZoneId.systemDefault());
+		return zonedDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+	}
 }

--- a/src/main/java/com/househub/backend/domain/agent/controller/AgentController.java
+++ b/src/main/java/com/househub/backend/domain/agent/controller/AgentController.java
@@ -1,29 +1,37 @@
 package com.househub.backend.domain.agent.controller;
 
-import com.househub.backend.common.response.SuccessResponse;
-import com.househub.backend.common.util.SecurityUtil;
-import com.househub.backend.domain.agent.dto.AgentResDto;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.househub.backend.common.response.SuccessResponse;
+import com.househub.backend.common.util.SecurityUtil;
+import com.househub.backend.domain.agent.dto.AgentResDto;
+import com.househub.backend.domain.agent.dto.GetMyInfoResDto;
+import com.househub.backend.domain.agent.service.AgentService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/agents")
+@RequiredArgsConstructor
 public class AgentController {
+	private final AgentService agentService;
 
-    @GetMapping("/me")
-    public ResponseEntity<SuccessResponse<AgentResDto>> getMyInfo() {
-        log.info("내 정보 조회 API 호출");
-        AgentResDto signInAgentInfo = SecurityUtil.getAuthenticatedAgent();
+	@GetMapping("/me")
+	public ResponseEntity<SuccessResponse<GetMyInfoResDto>> getMyInfo() {
+		log.info("내 정보 조회 API 호출");
+		AgentResDto signInAgentInfo = SecurityUtil.getAuthenticatedAgent();
+		GetMyInfoResDto response = agentService.getMyInfo(signInAgentInfo.getId());
 
-        return ResponseEntity.ok(SuccessResponse.success("내 정보 조회 성공", "GET_MY_INFO_SUCCESS", signInAgentInfo));
-    }
+		return ResponseEntity.ok(SuccessResponse.success("내 정보 조회 성공", "GET_MY_INFO_SUCCESS", response));
+	}
 
-    @GetMapping("")
-    public String hello() {
-        return "Hello, World!";
-    }
+	@GetMapping("")
+	public String hello() {
+		return "Hello, World!";
+	}
 }

--- a/src/main/java/com/househub/backend/domain/agent/dto/GetMyInfoResDto.java
+++ b/src/main/java/com/househub/backend/domain/agent/dto/GetMyInfoResDto.java
@@ -1,0 +1,67 @@
+package com.househub.backend.domain.agent.dto;
+
+import java.time.LocalDateTime;
+
+import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.agent.entity.AgentStatus;
+import com.househub.backend.domain.agent.entity.RealEstate;
+import com.househub.backend.domain.agent.entity.Role;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetMyInfoResDto {
+	private Long id;
+	private String email;
+	private String name;
+	private String contact;
+	private String licenseNumber;
+	private Role role;
+	private AgentStatus status;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private RealEstateResDto realEstate;
+
+	public static GetMyInfoResDto from(Agent agent) {
+		// 이 시점에서 RealEstate 엔티티가 데이터베이스에서 로딩됩니다.
+		RealEstate realEstate = agent.getRealEstate();
+		RealEstateResDto realEstateResDto = null;
+
+		if (realEstate != null) {
+			realEstateResDto = RealEstateResDto.builder()
+				.id(realEstate.getId())
+				.name(realEstate.getName())
+				.businessRegistrationNumber(realEstate.getBusinessRegistrationNumber())
+				.address(realEstate.getAddress())
+				.roadAddress(realEstate.getRoadAddress())
+				.contact(realEstate.getContact())
+				.build();
+		}
+
+		return GetMyInfoResDto.builder()
+			.id(agent.getId())
+			.email(agent.getEmail())
+			.name(agent.getName())
+			.contact(agent.getContact())
+			.licenseNumber(agent.getLicenseNumber())
+			.role(agent.getRole())
+			.status(agent.getStatus())
+			.createdAt(agent.getCreatedAt())
+			.updatedAt(agent.getUpdatedAt())
+			.realEstate(realEstateResDto)
+			.build();
+	}
+
+	@Getter
+	@Builder
+	public static class RealEstateResDto {
+		private Long id;
+		private String name;
+		private String businessRegistrationNumber;
+		private String address;
+		private String roadAddress;
+		private String contact;
+	}
+}

--- a/src/main/java/com/househub/backend/domain/agent/service/AgentService.java
+++ b/src/main/java/com/househub/backend/domain/agent/service/AgentService.java
@@ -1,0 +1,7 @@
+package com.househub.backend.domain.agent.service;
+
+import com.househub.backend.domain.agent.dto.GetMyInfoResDto;
+
+public interface AgentService {
+	GetMyInfoResDto getMyInfo(Long agentId);
+}

--- a/src/main/java/com/househub/backend/domain/agent/service/impl/AgentServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/agent/service/impl/AgentServiceImpl.java
@@ -1,0 +1,35 @@
+package com.househub.backend.domain.agent.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.househub.backend.common.exception.ResourceNotFoundException;
+import com.househub.backend.domain.agent.dto.GetMyInfoResDto;
+import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.agent.repository.AgentRepository;
+import com.househub.backend.domain.agent.service.AgentService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AgentServiceImpl implements AgentService {
+	private final AgentRepository agentRepository;
+
+	/**
+	 * 세션에 저장된 agentId 로 내 정보 조회
+	 * @param agentId 중개사 ID
+	 * @return GetMyInfoResDto 객체 (내 정보 조회 응답 DTO)
+	 * @throws IllegalArgumentException 중개사가 존재하지 않을 경우
+	 */
+	@Transactional(readOnly = true) // 트랜잭션 내에서 Lazy 로딩 가능
+	@Override
+	public GetMyInfoResDto getMyInfo(Long agentId) {
+		// 400 응답 처리해야 하는 게 맞는 건가요?
+		Agent agent = agentRepository.findById(agentId)
+			.orElseThrow(() -> new ResourceNotFoundException("해당하는 중개사가 없습니다.", "AGENT_NOT_FOUND"));
+
+		// 조회된 정보 토대로 GetMyInfoResDto 객체를 생성하여 반환한다.
+		return GetMyInfoResDto.from(agent);
+	}
+}

--- a/src/main/java/com/househub/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/househub/backend/domain/auth/controller/AuthController.java
@@ -1,91 +1,121 @@
 package com.househub.backend.domain.auth.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.househub.backend.common.exception.ResourceNotFoundException;
 import com.househub.backend.common.response.ErrorResponse;
 import com.househub.backend.common.response.SuccessResponse;
+import com.househub.backend.common.util.SecurityUtil;
+import com.househub.backend.common.util.SessionManager;
+import com.househub.backend.domain.agent.dto.AgentResDto;
+import com.househub.backend.domain.auth.dto.GetSessionResDto;
 import com.househub.backend.domain.auth.dto.SignInReqDto;
 import com.househub.backend.domain.auth.dto.SignInResDto;
 import com.househub.backend.domain.auth.dto.SignUpReqDto;
 import com.househub.backend.domain.auth.exception.EmailVerifiedException;
 import com.househub.backend.domain.auth.exception.InvalidPasswordException;
 import com.househub.backend.domain.auth.service.AuthService;
-import jakarta.servlet.http.HttpServletRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
-    private final AuthService authService;
+	private final AuthService authService;
 
-    // 회원가입
-    @PostMapping("/signup")
-    public ResponseEntity<SuccessResponse<Void>> signup(@Valid @RequestBody SignUpReqDto request) {
-        log.info("{}", request.getAgent());
-        log.info("{}", request.getRealEstate());
+	// 회원가입
+	@PostMapping("/signup")
+	public ResponseEntity<SuccessResponse<Void>> signup(@Valid @RequestBody SignUpReqDto request) {
+		log.info("{}", request.getAgent());
+		log.info("{}", request.getRealEstate());
 
-        authService.signup(request);
+		authService.signup(request);
 
-        return ResponseEntity.ok(SuccessResponse.success("회원가입 성공.", "SIGNUP_SUCCESS", null));
-    }
+		return ResponseEntity.ok(SuccessResponse.success("회원가입 성공.", "SIGNUP_SUCCESS", null));
+	}
 
-    // 로그인
-    @PostMapping("/signin")
-    public ResponseEntity<SuccessResponse<SignInResDto>> signin(
-            @Valid @RequestBody SignInReqDto request
-    ) {
-        log.info("{}: {}", request.getEmail(), request.getPassword());
+	// 로그인
+	@PostMapping("/signin")
+	public ResponseEntity<SuccessResponse<SignInResDto>> signin(
+		@Valid @RequestBody SignInReqDto request
+	) {
+		try {
+			log.info("{}: {}", request.getEmail(), request.getPassword());
 
-        log.info("로그인 비즈니스 로직 시작");
-        SignInResDto signInAgentInfo = authService.signin(request);
-        log.info("로그인 비즈니스 로직 종료");
+			log.info("로그인 비즈니스 로직 시작");
+			SignInResDto signInAgentInfo = authService.signin(request);
+			log.info("로그인 비즈니스 로직 종료");
 
-        // 응답 본문에는 에이전트 정보를 제외하고 상태만 반환
-        return ResponseEntity.ok(SuccessResponse.success("로그인 성공.", "SIGNIN_SUCCESS", signInAgentInfo));
-    }
+			// 응답 본문에는 에이전트 정보를 제외하고 상태만 반환
+			return ResponseEntity.ok(SuccessResponse.success("로그인 성공.", "SIGNIN_SUCCESS", signInAgentInfo));
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw e;
+		}
+	}
 
-    @ExceptionHandler({
-            ResourceNotFoundException.class,
-            EmailVerifiedException.class,
-            InvalidPasswordException.class
-    })
-    public ResponseEntity<ErrorResponse> handleLoginExceptions(RuntimeException ex) {
-        if (ex instanceof EmailVerifiedException) {
-            return ResponseEntity
-                .badRequest()
-                .body(
-                    ErrorResponse.builder()
-                        .message(ex.getMessage())
-                        .code(((EmailVerifiedException) ex).getCode())
-                        .build());
-        }
+	@Operation(summary = "세션 정보 조회", description = "현재 세션에 저장된 사용자 정보를 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "세션 정보 조회 성공")
+	@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+	@ApiResponse(responseCode = "500", description = "서버 오류")
+	@GetMapping("/session")
+	public ResponseEntity<SuccessResponse<GetSessionResDto>> getSession(HttpSession session) {
+		AgentResDto signInAgent = SecurityUtil.getAuthenticatedAgent();
+		GetSessionResDto response = GetSessionResDto.builder()
+			.id(signInAgent.getId())
+			.name(signInAgent.getName())
+			.email(signInAgent.getEmail())
+			.role(signInAgent.getRole())
+			.isAuthenticated(true)
+			.expiresAt(SessionManager.getSessionExpirationTime(session.getMaxInactiveInterval()))
+			.build();
 
-        else if (ex instanceof InvalidPasswordException) {
-            return ResponseEntity
-                    .status(HttpStatus.UNAUTHORIZED)
-                    .body(
-                        ErrorResponse.builder()
-                            .message(ex.getMessage())
-                            .code(((InvalidPasswordException) ex).getCode())
-                            .build());
-        }
+		return ResponseEntity.ok(SuccessResponse.success("세션 정보 조회 성공", "GET_SESSION_SUCCESS", response));
+	}
 
-        else if (ex instanceof ResourceNotFoundException) {
-            throw ex;
-        }
-
-        else {
-            // 기타 예상치 못한 예외 처리
-            return ResponseEntity
-                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ErrorResponse.builder().message("로그인 중 알 수 없는 오류가 발생했습니다.").code("LOGIN_ERROR").build());
-        }
-    }
+	@ExceptionHandler({
+		ResourceNotFoundException.class,
+		EmailVerifiedException.class,
+		InvalidPasswordException.class
+	})
+	public ResponseEntity<ErrorResponse> handleLoginExceptions(RuntimeException ex) {
+		if (ex instanceof EmailVerifiedException) {
+			return ResponseEntity
+				.badRequest()
+				.body(
+					ErrorResponse.builder()
+						.message(ex.getMessage())
+						.code(((EmailVerifiedException)ex).getCode())
+						.build());
+		} else if (ex instanceof InvalidPasswordException) {
+			return ResponseEntity
+				.status(HttpStatus.UNAUTHORIZED)
+				.body(
+					ErrorResponse.builder()
+						.message(ex.getMessage())
+						.code(((InvalidPasswordException)ex).getCode())
+						.build());
+		} else if (ex instanceof ResourceNotFoundException) {
+			throw ex;
+		} else {
+			// 기타 예상치 못한 예외 처리
+			return ResponseEntity
+				.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(ErrorResponse.builder().message("로그인 중 알 수 없는 오류가 발생했습니다.").code("LOGIN_ERROR").build());
+		}
+	}
 }

--- a/src/main/java/com/househub/backend/domain/auth/dto/GetSessionResDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/GetSessionResDto.java
@@ -1,0 +1,17 @@
+package com.househub.backend.domain.auth.dto;
+
+import com.househub.backend.domain.agent.entity.Role;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GetSessionResDto {
+	private Long id; // 사용자 식별자
+	private String name; // 사용자 이름
+	private String email; // 사용자 이메일
+	private Role role; // 사용자 권한(ADMIN, AGENT)
+	private boolean isAuthenticated; // 인증 여부
+	private String expiresAt; // 세션 만료 시간
+}

--- a/src/main/java/com/househub/backend/domain/auth/dto/SignInReqDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/SignInReqDto.java
@@ -2,16 +2,20 @@ package com.househub.backend.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SignInReqDto {
-    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String email;
+	@NotBlank(message = "이메일은 필수 입력 항목입니다.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	private String email;
 
-    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
-    private String password;
+	@NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+	private String password;
 }

--- a/src/main/java/com/househub/backend/domain/auth/dto/SignInReqDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/SignInReqDto.java
@@ -18,4 +18,6 @@ public class SignInReqDto {
 
 	@NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
 	private String password;
+
+	private boolean rememberMe;
 }

--- a/src/main/java/com/househub/backend/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/auth/service/impl/AuthServiceImpl.java
@@ -1,11 +1,22 @@
 package com.househub.backend.domain.auth.service.impl;
 
+import java.util.Optional;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
 import com.househub.backend.common.exception.AlreadyExistsException;
 import com.househub.backend.common.exception.ResourceNotFoundException;
-import com.househub.backend.common.exception.UnauthorizedException;
 import com.househub.backend.common.util.SessionManager;
 import com.househub.backend.domain.agent.entity.Agent;
-import com.househub.backend.domain.agent.entity.AgentStatus;
 import com.househub.backend.domain.agent.entity.RealEstate;
 import com.househub.backend.domain.agent.entity.Role;
 import com.househub.backend.domain.agent.repository.AgentRepository;
@@ -16,216 +27,198 @@ import com.househub.backend.domain.auth.exception.EmailVerifiedException;
 import com.househub.backend.domain.auth.exception.InvalidPasswordException;
 import com.househub.backend.domain.auth.service.AuthService;
 import com.househub.backend.domain.realEstate.repository.RealEstateRepository;
-import jakarta.servlet.http.HttpSession;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.InternalAuthenticationServiceException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
-
-import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
-    private final AgentRepository agentRepository;
-    private final RealEstateRepository realEstateRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final AuthenticationManager authenticationManager;
-    private final SessionManager sessionManager;
+	private final AgentRepository agentRepository;
+	private final RealEstateRepository realEstateRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final AuthenticationManager authenticationManager;
+	private final SessionManager sessionManager;
 
+	/**
+	 * 부동산 공인중개사 회원가입
+	 *
+	 * @param request 회원가입 요청 정보
+	 * @throws EmailVerifiedException 이메일 인증이 완료되지 않은 경우 발생
+	 */
+	@Transactional
+	@Override
+	public void signup(SignUpReqDto request) {
+		SignUpReqDto.AgentDto agentDto = request.getAgent();
+		Optional<SignUpReqDto.RealEstateDto> realEstateDtoOptional = Optional.ofNullable(request.getRealEstate());
 
-    /**
-     * 부동산 공인중개사 회원가입
-     *
-     * @param request 회원가입 요청 정보
-     * @throws EmailVerifiedException 이메일 인증이 완료되지 않은 경우 발생
-     */
-    @Transactional
-    @Override
-    public void signup(SignUpReqDto request) {
-        SignUpReqDto.AgentDto agentDto = request.getAgent();
-        Optional<SignUpReqDto.RealEstateDto> realEstateDtoOptional = Optional.ofNullable(request.getRealEstate());
+		// 이메일 인증 여부에 따른 예외 처리
+		validateEmailVerification(agentDto);
 
-        // realEstateDto가 null인 경우 기본값 설정 또는 예외 처리
-        SignUpReqDto.RealEstateDto realEstateDto = realEstateDtoOptional.orElse(null); // null 허용 또는 기본값 설정
+		// 이메일 중복 여부 검증
+		checkEmailDuplication(agentDto.getEmail());
 
-        // 이메일 인증 여부에 따른 예외 처리
-        validateEmailVerification(agentDto);
+		// 자격증번호 값이 들어오면, 중개사의 자격증 번호 이미 존재하는지 확인
+		validateLicenseNumber(agentDto.getLicenseNumber());
 
-        // 이메일 중복 여부 검증
-        checkEmailDuplication(agentDto.getEmail());
+		// 부동산 정보가 입력받은 게 없으면 기본값(null) 설정
+		// 부동산 사업자 등록 번호 이미 존재하는지 확인
+		// 존재하지 않으면 부동산 정보 새로 저장
+		RealEstate realEstate = realEstateDtoOptional.map(this::getOrCreateRealEstate).orElse(null);
 
-        // 자격증번호 값이 들어오면, 중개사의 자격증 번호 이미 존재하는지 확인
-        validateLicenseNumber(agentDto.getLicenseNumber());
+		// 증개사 정보 저장
+		saveAgent(request.getAgent(), realEstate);
+	}
 
-        // 부동산 사업자 등록 번호 이미 존재하는지 확인
-        // 존재하지 않으면 부동산 정보 새로 저장
-        RealEstate realEstate = getOrCreateRealEstate(realEstateDto);
+	/**
+	 * 에이전트 로그인 처리.
+	 *
+	 * @param request 로그인 요청 정보 (이메일, 비밀번호)
+	 * @return 로그인 성공 시 에이전트 정보 (ID, 이메일)
+	 * @throws ResourceNotFoundException     해당 이메일의 사용자를 찾을 수 없는 경우
+	 * @throws InvalidPasswordException 비밀번호가 일치하지 않는 경우
+	 */
+	@Transactional
+	@Override
+	public SignInResDto signin(SignInReqDto request) {
+		try {
+			log.info("사용자 인증 시도");
+			// 사용자 인증
+			Authentication authentication = authenticateUser(request);
 
-        // 증개사 정보 저장
-        saveAgent(request.getAgent(), realEstate);
-    }
+			// 사용자 정보 조회
+			Agent existingAgent = findAgentByEmail(request.getEmail());
 
-    /**
-     * 에이전트 로그인 처리.
-     *
-     * @param request 로그인 요청 정보 (이메일, 비밀번호)
-     * @return 로그인 성공 시 에이전트 정보 (ID, 이메일)
-     * @throws ResourceNotFoundException     해당 이메일의 사용자를 찾을 수 없는 경우
-     * @throws InvalidPasswordException 비밀번호가 일치하지 않는 경우
-     */
-    @Transactional
-    @Override
-    public SignInResDto signin(SignInReqDto request) {
-        try {
-            log.info("사용자 인증 시도");
-            // 사용자 인증
-            Authentication authentication = authenticateUser(request);
+			// 세션 관리
+			sessionManager.manageAgentSession(authentication);
 
-            // 사용자 정보 조회
-            Agent existingAgent = findAgentByEmail(request.getEmail());
+			return SignInResDto.builder()
+				.id(existingAgent.getId())
+				.email(existingAgent.getEmail())
+				.build();
+		} catch (InternalAuthenticationServiceException ex) {
+			log.warn("로그인 실패 - 사용자를 찾을 수 없음: {}", request.getEmail());
+			throw new UsernameNotFoundException("해당 이메일과 일치하는 중개사가 존재하지 않습니다.");
+		} catch (BadCredentialsException ex) {
+			log.warn("로그인 실패 - 잘못된 자격 증명: {}", request.getEmail());
+			throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+		} catch (Exception ex) {
+			log.error("로그인 중 예외 발생: {}", ex.getMessage(), ex);
+			throw ex;
+		}
+	}
 
-            // 세션 관리
-            sessionManager.manageAgentSession(authentication);
+	private Authentication authenticateUser(SignInReqDto request) {
+		UsernamePasswordAuthenticationToken token =
+			new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
+		return authenticationManager.authenticate(token);
+	}
 
-            return SignInResDto.builder()
-                .id(existingAgent.getId())
-                .email(existingAgent.getEmail())
-                .build();
-        } catch (InternalAuthenticationServiceException ex) {
-            log.warn("로그인 실패 - 사용자를 찾을 수 없음: {}", request.getEmail());
-            throw new UsernameNotFoundException("해당 이메일과 일치하는 중개사가 존재하지 않습니다.");
-        } catch (BadCredentialsException ex) {
-            log.warn("로그인 실패 - 잘못된 자격 증명: {}", request.getEmail());
-            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
-        }  catch (Exception ex) {
-            log.error("로그인 중 예외 발생: {}", ex.getMessage(), ex);
-            throw ex;
-        }
-    }
+	private Agent findAgentByEmail(String email) {
+		return agentRepository.findByEmail(email)
+			.orElseThrow(() -> new ResourceNotFoundException(
+				"해당 이메일의 사용자를 찾을 수 없습니다.",
+				"AGENT_NOT_FOUND"
+			));
+	}
 
-    private Authentication authenticateUser(SignInReqDto request) {
-        UsernamePasswordAuthenticationToken token =
-                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
-        return authenticationManager.authenticate(token);
-    }
+	/**
+	 * 이메일 인증 여부를 확인하고, 인증되지 않은 경우 예외를 발생시킵니다.
+	 *
+	 * @param agentDto 회원가입 요청에 포함된 중개사 정보
+	 * @throws EmailVerifiedException 이메일 인증이 완료되지 않은 경우 발생
+	 */
+	private void validateEmailVerification(SignUpReqDto.AgentDto agentDto) {
+		log.info("{}", agentDto.toString());
+		if (!agentDto.isEmailVerified()) {
+			throw new EmailVerifiedException("이메일 인증이 완료되지 않았습니다.", "EMAIL_NOT_VERIFIED");
+		}
+	}
 
-    private Agent findAgentByEmail(String email) {
-        return agentRepository.findByEmail(email)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "해당 이메일의 사용자를 찾을 수 없습니다.",
-                        "AGENT_NOT_FOUND"
-                ));
-    }
+	/**
+	 * 이메일 중복 여부를 확인하고, 이미 등록된 이메일이 있는 경우 예외를 발생시킵니다.
+	 *
+	 * @param email 중복을 확인할 이메일
+	 * @throws AlreadyExistsException 이메일이 이미 등록되어 있을 경우 발생
+	 */
+	private void checkEmailDuplication(String email) {
+		Optional<Agent> existingAgent = agentRepository.findByEmail(email);
+		if (existingAgent.isPresent()) {
+			throw new AlreadyExistsException("이미 등록된 이메일입니다.", "EMAIL_ALREADY_EXISTS");
+		}
+	}
 
-    /**
-     * 이메일 인증 여부를 확인하고, 인증되지 않은 경우 예외를 발생시킵니다.
-     *
-     * @param agentDto 회원가입 요청에 포함된 중개사 정보
-     * @throws EmailVerifiedException 이메일 인증이 완료되지 않은 경우 발생
-     */
-    private void validateEmailVerification(SignUpReqDto.AgentDto agentDto) {
-        log.info("{}", agentDto.toString());
-        if (!agentDto.isEmailVerified()) {
-            throw new EmailVerifiedException("이메일 인증이 완료되지 않았습니다.", "EMAIL_NOT_VERIFIED");
-        }
-    }
+	/**
+	 * 자격증 번호의 중복 여부를 검증합니다.
+	 *
+	 * @param licenseNumber 검증할 자격증 번호
+	 * @throws AlreadyExistsException 자격증 번호가 이미 존재하는 경우 발생
+	 */
+	private void validateLicenseNumber(String licenseNumber) {
+		if (!StringUtils.hasText(licenseNumber)) {
+			return; // 자격증 번호가 없으면 검사할 필요 없음.
+		}
+		agentRepository.findByLicenseNumber(licenseNumber)
+			.ifPresent(agent -> {
+				log.error("이미 존재하는 자격증 번호: {}", agent.getLicenseNumber());
+				throw new AlreadyExistsException("이미 존재하는 자격증 번호입니다.", "LICENSE_NUMBER_ALREADY_EXISTS");
+			});
+	}
 
-    /**
-     * 이메일 중복 여부를 확인하고, 이미 등록된 이메일이 있는 경우 예외를 발생시킵니다.
-     *
-     * @param email 중복을 확인할 이메일
-     * @throws AlreadyExistsException 이메일이 이미 등록되어 있을 경우 발생
-     */
-    private void checkEmailDuplication(String email) {
-        Optional<Agent> existingAgent = agentRepository.findByEmail(email);
-        if (existingAgent.isPresent()) {
-            throw new AlreadyExistsException("이미 등록된 이메일입니다.", "EMAIL_ALREADY_EXISTS");
-        }
-    }
+	/**
+	 * 부동산 사업자 등록 번호의 존재 여부를 확인하고, 존재하지 않으면 새로운 부동산 정보를 저장합니다.
+	 *
+	 * @param realEstateDto 부동산 정보 DTO
+	 * @return 저장된 또는 존재하는 부동산 엔티티
+	 */
+	private RealEstate getOrCreateRealEstate(SignUpReqDto.RealEstateDto realEstateDto) {
+		return realEstateRepository.findByBusinessRegistrationNumber(realEstateDto.getBusinessRegistrationNumber())
+			.orElseGet(() -> realEstateRepository.save(toRealEstateEntity(realEstateDto)));
+	}
 
-    /**
-     * 자격증 번호의 중복 여부를 검증합니다.
-     *
-     * @param licenseNumber 검증할 자격증 번호
-     * @throws AlreadyExistsException 자격증 번호가 이미 존재하는 경우 발생
-     */
-    private void validateLicenseNumber(String licenseNumber) {
-        if (!StringUtils.hasText(licenseNumber)) {
-            return; // 자격증 번호가 없으면 검사할 필요 없음.
-        }
-        agentRepository.findByLicenseNumber(licenseNumber)
-                .ifPresent(agent -> {
-                    log.error("이미 존재하는 자격증 번호: {}", agent.getLicenseNumber());
-                    throw new AlreadyExistsException("이미 존재하는 자격증 번호입니다.", "LICENSE_NUMBER_ALREADY_EXISTS");
-                });
-    }
+	/**
+	 * 공인중개사 정보를 저장합니다.
+	 *
+	 * @param agentDto 공인중개사 정보 DTO
+	 * @param realEstate 부동산 엔티티
+	 */
+	private void saveAgent(SignUpReqDto.AgentDto agentDto, RealEstate realEstate) {
+		agentRepository.save(toAgentEntity(agentDto, realEstate));
+	}
 
-    /**
-     * 부동산 사업자 등록 번호의 존재 여부를 확인하고, 존재하지 않으면 새로운 부동산 정보를 저장합니다.
-     *
-     * @param realEstateDto 부동산 정보 DTO
-     * @return 저장된 또는 존재하는 부동산 엔티티
-     */
-    private RealEstate getOrCreateRealEstate(SignUpReqDto.RealEstateDto realEstateDto) {
-        return realEstateRepository.findByBusinessRegistrationNumber(realEstateDto.getBusinessRegistrationNumber())
-                .orElseGet(() -> realEstateRepository.save(toRealEstateEntity(realEstateDto)));
-    }
+	/**
+	 * RequestDto 의 부동산 정보를 RealEstate 엔티티로 변환합니다.
+	 *
+	 * @param realEstateDTO 부동산 정보 DTO
+	 * @return RealEstate 엔티티
+	 */
+	private RealEstate toRealEstateEntity(SignUpReqDto.RealEstateDto realEstateDTO) {
+		return RealEstate.builder()
+			.name(realEstateDTO.getName())
+			.businessRegistrationNumber(realEstateDTO.getBusinessRegistrationNumber())
+			.address(realEstateDTO.getAddress())
+			.roadAddress(realEstateDTO.getRoadAddress())
+			.contact(realEstateDTO.getContact())
+			.build();
+	}
 
-    /**
-     * 공인중개사 정보를 저장합니다.
-     *
-     * @param agentDto 공인중개사 정보 DTO
-     * @param realEstate 부동산 엔티티
-     */
-    private void saveAgent(SignUpReqDto.AgentDto agentDto, RealEstate realEstate) {
-        agentRepository.save(toAgentEntity(agentDto, realEstate));
-    }
-
-    /**
-     * RequestDto 의 부동산 정보를 RealEstate 엔티티로 변환합니다.
-     *
-     * @param realEstateDTO 부동산 정보 DTO
-     * @return RealEstate 엔티티
-     */
-    private RealEstate toRealEstateEntity(SignUpReqDto.RealEstateDto realEstateDTO) {
-        return RealEstate.builder()
-                .name(realEstateDTO.getName())
-                .businessRegistrationNumber(realEstateDTO.getBusinessRegistrationNumber())
-                .address(realEstateDTO.getAddress())
-                .roadAddress(realEstateDTO.getRoadAddress())
-                .contact(realEstateDTO.getContact())
-                .build();
-    }
-
-    /**
-     * RequestDto 의 공인중개사 정보를 Agent 엔티티로 변환합니다.
-     *
-     * @param agentDTO 공인중개사 정보 DTO
-     * @param realEstate 부동산 엔티티
-     * @return Agent 엔티티
-     */
-    private Agent toAgentEntity(SignUpReqDto.AgentDto agentDTO, RealEstate realEstate) {
-        return Agent.builder()
-                .name(agentDTO.getName())
-                .licenseNumber(agentDTO.getLicenseNumber())
-                .email(agentDTO.getEmail())
-                .password(passwordEncoder.encode(agentDTO.getPassword()))
-                .contact(agentDTO.getContact())
-                .realEstate(realEstate)
-                .role(Role.AGENT)
-                .build();
-    }
+	/**
+	 * RequestDto 의 공인중개사 정보를 Agent 엔티티로 변환합니다.
+	 *
+	 * @param agentDTO 공인중개사 정보 DTO
+	 * @param realEstate 부동산 엔티티
+	 * @return Agent 엔티티
+	 */
+	private Agent toAgentEntity(SignUpReqDto.AgentDto agentDTO, RealEstate realEstate) {
+		return Agent.builder()
+			.name(agentDTO.getName())
+			.licenseNumber(agentDTO.getLicenseNumber())
+			.email(agentDTO.getEmail())
+			.password(passwordEncoder.encode(agentDTO.getPassword()))
+			.contact(agentDTO.getContact())
+			.realEstate(realEstate)
+			.role(Role.AGENT)
+			.build();
+	}
 }


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 공인중개사 회원가입, 로그인 API 수정
- 세션 조회 API 구현
- 내 정보(공인중개사 본인) 조회 API 응답 데이터로 부동산 정보 추가(입력 안 한 경우 null)
- CORS 설정

## ✏️ 변경 사항
- 공인중개사 회원가입 시 부동산 정보가 누락되는 경우 사업자 등록 번호 조회 후 없는 경우 부동산 엔티티 저장하는 로직 개선
- 세션 조회 API 추가
  - GET /api/auth/session API를 추가하여 현재 세션 정보를 반환합니다.
  - 세션 정보에는 사용자 ID, 역할, 로그인 상태 등이 포함됩니다.
- 내 정보 조회 API 응답 데이터에 부동산 정보 추가
- 로그인 요청 DTO 에러 해결(@NoArgsConstructor 누락) 및 rememberMe 필드 추가
- 프론트엔드와의 연동을 위한 CORS 인증 필터 적용

## 📸 스크린샷 (선택사항)
- UI 변경이나 기능 추가 시 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈
- #60
