### PR TITLE
byungchan, feature: 인증 메일 발송 API 응답 데이터 변경 및 merge conflict 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM openjdk:17-jdk-slim
-
+# 빌드 스테이지
+FROM gradle:7.6.1-jdk17 AS builder
 WORKDIR /app
+COPY . .
+RUN gradle bootJar # 빌드 실행
 
-COPY ./build/libs/*.jar app.jar
-
+# 런타임 스테이지
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
 RUN ls -l
-
 EXPOSE 8080
-
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,6 @@ dependencies {
     runtimeOnly 'org.apache.logging.log4j:log4j-core:2.20.0'
 
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-    //엑셀 파싱 관련 의존성
-    implementation 'org.apache.poi:poi:5.2.3'
-    implementation 'org.apache.poi:poi-ooxml:5.2.3'
-    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.20.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,56 +1,60 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.househub'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'jakarta.validation:jakarta.validation-api'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.session:spring-session-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
-	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation("org.springframework.security:spring-security-test")
-	testImplementation 'org.mockito:mockito-junit-jupiter'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'jakarta.validation:jakarta.validation-api'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
+    runtimeOnly 'mysql:mysql-connector-java:8.0.33'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation("org.springframework.security:spring-security-test")
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//엑셀 파싱 관련 의존성
-	implementation 'org.apache.poi:poi:5.2.3'
-	implementation 'org.apache.poi:poi-ooxml:5.2.3'
-	runtimeOnly 'org.apache.logging.log4j:log4j-core:2.20.0'
+    //엑셀 파싱 관련 의존성
+    implementation 'org.apache.poi:poi:5.2.3'
+    implementation 'org.apache.poi:poi-ooxml:5.2.3'
+    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.20.0'
 
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    //엑셀 파싱 관련 의존성
+    implementation 'org.apache.poi:poi:5.2.3'
+    implementation 'org.apache.poi:poi-ooxml:5.2.3'
+    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.20.0'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,11 +16,7 @@ module.exports = {
                 },
                 'type-enum': ({ type }) => {
                     const realType = type ?? '';
-<<<<<<< HEAD
-                    const allowedTypes = ['feat', 'hotfix', 'chore','feature','fix'];
-=======
-                    const allowedTypes = ['feat', 'hotfix', 'chore', 'fix', 'docs'];
->>>>>>> 05f0fee (byungchan, fix: merge conflict 해결 #56)
+                    const allowedTypes = ['feat', 'hotfix', 'chore','feature','fix', 'docs'];
                     return [allowedTypes.includes(realType), `타입은 ${allowedTypes.join(', ')} 중 하나여야 합니다`];
                 },
                 'subject-empty': ({ subject }) => {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,7 +16,11 @@ module.exports = {
                 },
                 'type-enum': ({ type }) => {
                     const realType = type ?? '';
+<<<<<<< HEAD
                     const allowedTypes = ['feat', 'hotfix', 'chore','feature','fix'];
+=======
+                    const allowedTypes = ['feat', 'hotfix', 'chore', 'fix', 'docs'];
+>>>>>>> 05f0fee (byungchan, fix: merge conflict 해결 #56)
                     return [allowedTypes.includes(realType), `타입은 ${allowedTypes.join(', ')} 중 하나여야 합니다`];
                 },
                 'subject-empty': ({ subject }) => {

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,63 @@
+version: '3.8'
+
+services:
+#  househub-nginx:
+#    container_name: househub-nginx
+#    image: nginx:latest
+#    ports:
+#      - "80:80"
+#    volumes:
+#      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+#    depends_on:
+#      - househub-backend
+#    networks:
+#      - backend-network
+
+  househub-backend:
+    container_name: househub-backend
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    networks:
+      - backend-network
+    depends_on:
+      - househub-mysql # mysql 추가
+
+  househub-redis:
+    container_name: househub-redis
+    image: redis:6.2.6-alpine
+    ports:
+      - "6379:6379"
+    command: redis-server /etc/redis/redis.conf
+    volumes:
+      - ./redis/redis.conf:/etc/redis/redis.conf
+    networks:
+      - backend-network
+    environment:
+      - REDIS_PASSWORD=1234567890
+
+  househub-mysql: # mysql 서비스 추가
+    container_name: househub-mysql
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234 # mysql 비밀번호 설정
+      MYSQL_DATABASE: househub_db # 데이터베이스 이름 설정
+    volumes:
+      - mysql-data:/var/lib/mysql # 데이터 영속화
+    networks:
+      - backend-network
+    healthcheck: # mysql 헬스체크 추가
+      test: ["CMD", "mysqladmin", "ping", "-h", "househub-mysql"]
+      timeout: 20s
+      retries: 10
+
+networks:
+  backend-network: # 네트워크 정의
+    driver: bridge # 브리지 네트워크 사용
+
+volumes:
+  mysql-data: # mysql 데이터 볼륨 정의

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,26 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include mime.types;
+    default_type application/json; # JSON API 이므로 변경
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location /api/ {
+            proxy_pass http://househub-backend:8080/api/;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+        }
+    }
+}
+

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,0 +1,3 @@
+requirepass 1234567890
+maxmemory 1gb
+maxmemory-policy allkeys-lru

--- a/src/main/java/com/househub/backend/common/config/RedisConfig.java
+++ b/src/main/java/com/househub/backend/common/config/RedisConfig.java
@@ -1,6 +1,5 @@
 package com.househub.backend.common.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,8 +8,8 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+import lombok.RequiredArgsConstructor;
 
 /**
  * Redis 설정 클래스
@@ -20,36 +19,36 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 @EnableRedisRepositories
 @RequiredArgsConstructor
 public class RedisConfig {
-    @Value("${spring.data.redis.host:localhost}")
-    private String host;
+	@Value("${spring.data.redis.host:localhost}")
+	private String host;
 
-    @Value("${spring.data.redis.port:6379}")
-    private int port;
+	@Value("${spring.data.redis.port:6379}")
+	private int port;
 
-    /**
-     * Redis 연결 팩토리 빈 생성
-     * Lettuce를 사용하여 Redis 연결 생성.
-     *
-     * @return RedisConnectionFactory Redis 연결 팩토리
-     */
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
-    }
+	/**
+	 * Redis 연결 팩토리 빈 생성
+	 * Lettuce를 사용하여 Redis 연결 생성.
+	 *
+	 * @return RedisConnectionFactory Redis 연결 팩토리
+	 */
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory("localhost", 6379);
+	}
 
-    /**
-     * RedisTemplate 빈 생성
-     * Redis에 데이터를 저장하고 조회하는 데 사용되는 템플릿
-     * 키와 값을 String 타입으로 직렬화/역직렬화하도록 설정
-     *
-     * @return RedisTemplate Redis 템플릿
-     */
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setKeySerializer(new StringRedisSerializer()); // 키 직렬화/역직렬화 설정
-        redisTemplate.setValueSerializer(new StringRedisSerializer()); // 값 직렬화/역직렬화 설정
-        redisTemplate.setConnectionFactory(redisConnectionFactory()); // 연결 팩토리 설정
-        return redisTemplate;
-    }
+	/**
+	 * RedisTemplate 빈 생성
+	 * Redis에 데이터를 저장하고 조회하는 데 사용되는 템플릿
+	 * 키와 값을 String 타입으로 직렬화/역직렬화하도록 설정
+	 *
+	 * @return RedisTemplate Redis 템플릿
+	 */
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setKeySerializer(new StringRedisSerializer()); // 키 직렬화/역직렬화 설정
+		redisTemplate.setValueSerializer(new StringRedisSerializer()); // 값 직렬화/역직렬화 설정
+		redisTemplate.setConnectionFactory(redisConnectionFactory()); // 연결 팩토리 설정
+		return redisTemplate;
+	}
 }

--- a/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
@@ -45,9 +45,13 @@ public class WebSecurityConfig {
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.authorizeHttpRequests((authz) -> authz
 				.requestMatchers(
+					"/api/auth/session",
 					"/api/auth/email/**",
 					"/api/auth/signup",
 					"/api/auth/signin",
+					"/api/auth/signup",
+					"/api/auth/signin",
+					"/api/auth/email/**",
 					"/v3/api-docs/**",
 					"/swagger-ui/**",
 					"/swagger-ui.html"

--- a/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
@@ -45,6 +45,7 @@ public class WebSecurityConfig {
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.authorizeHttpRequests((authz) -> authz
 				.requestMatchers(
+					"/api/auth/email/**",
 					"/api/auth/signup",
 					"/api/auth/signin",
 					"/v3/api-docs/**",

--- a/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
@@ -19,11 +19,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AlreadyExistsException.class)
     public ResponseEntity<ErrorResponse> handleAlreadyExistsException(AlreadyExistsException ex) {
         ErrorResponse response = ErrorResponse.builder()
-                .success(false)
-                .message(ex.getMessage())
-                .code(ex.getCode())
-                .errors(null)
-                .build();
+            .success(false)
+            .message(ex.getMessage())
+            .code(ex.getCode())
+            .errors(null)
+            .build();
 
         return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
@@ -31,11 +31,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException ex) {
         ErrorResponse response = ErrorResponse.builder()
-                .success(false)
-                .message(ex.getMessage())
-                .code(ex.getCode())
-                .errors(null)
-                .build();
+            .success(false)
+            .message(ex.getMessage())
+            .code(ex.getCode())
+            .errors(null)
+            .build();
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
@@ -44,15 +44,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
         List<ErrorResponse.FieldError> fieldErrors = ex.getFieldErrors().stream()
-                .map(fieldError -> ErrorResponse.FieldError.builder().field(fieldError.getField()).message(fieldError.getDefaultMessage()).build())
-                .collect(Collectors.toList());
+            .map(fieldError -> ErrorResponse.FieldError.builder()
+                .field(fieldError.getField())
+                .message(fieldError.getDefaultMessage())
+                .build())
+            .collect(Collectors.toList());
 
         ErrorResponse response = ErrorResponse.builder()
-                .success(false)
-                .message("입력값을 확인해주세요.")
-                .code("VALIDATION_ERROR")
-                .errors(fieldErrors)
-                .build();
+            .success(false)
+            .message("입력값을 확인해주세요.")
+            .code("VALIDATION_ERROR")
+            .errors(fieldErrors)
+            .build();
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
@@ -60,11 +63,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleInternalServerError(Exception ex) {
         ErrorResponse response = ErrorResponse.builder()
-                .success(false)
-                .message("서버 내부 오류가 발생했습니다.")
-                .code("INTERNAL_SERVER_ERROR")
-                .errors(null)
-                .build();
+            .success(false)
+            .message("서버 내부 오류가 발생했습니다.")
+            .code("INTERNAL_SERVER_ERROR")
+            .errors(null)
+            .build();
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
@@ -76,11 +79,11 @@ public class GlobalExceptionHandler {
 
         // ErrorResponse 객체 생성
         ErrorResponse errorResponse = ErrorResponse.builder()
-                .success(false)
-                .message(ex.getMessage())
-                .code(ex.getCode())
-                .errors(fieldErrors)
-                .build();
+            .success(false)
+            .message(ex.getMessage())
+            .code(ex.getCode())
+            .errors(fieldErrors)
+            .build();
 
         // HTTP 응답으로 반환
         return ResponseEntity.badRequest().body(errorResponse);

--- a/src/main/java/com/househub/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/househub/backend/domain/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.househub.backend.domain.auth.controller;
 
+import java.time.LocalDateTime;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -40,7 +42,11 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthController {
 	private final AuthService authService;
 
-	// 회원가입
+	/**
+	 * 회원가입
+	 * @param request 회원가입 요청 정보
+	 * @return 회원가입 성공 여부
+	 */
 	@PostMapping("/signup")
 	public ResponseEntity<SuccessResponse<Void>> signup(@Valid @RequestBody SignUpReqDto request) {
 		log.info("{}", request.getAgent());
@@ -120,8 +126,10 @@ public class AuthController {
 	@PostMapping("/email/send")
 	public ResponseEntity<SuccessResponse<SendEmailResDto>> sendEmail(@Valid @RequestBody SendEmailReqDto request) {
 		String authCode = authService.generateAndSaveAuthCode(request.getEmail());
+		log.info("인증 코드: {}", authCode);
+		String expiresAt = String.valueOf(LocalDateTime.now().plusMinutes(3));
 		return ResponseEntity.ok(SuccessResponse.success("이메일 발송 성공", "EMAIL_SEND_SUCCESS",
-			SendEmailResDto.builder().authCode(authCode).build()));
+			SendEmailResDto.builder().expiresAt(expiresAt).build()));
 	}
 
 	@PostMapping("/email/verify")

--- a/src/main/java/com/househub/backend/domain/auth/dto/SendEmailReqDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/SendEmailReqDto.java
@@ -1,0 +1,26 @@
+package com.househub.backend.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendEmailReqDto {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "잘못된 이메일 형식입니다.")
+    private String email;
+
+    @NotNull(message = "요청 타입을 입력해주세요.")
+    private ReqType type;
+
+    private enum ReqType {
+        SIGNUP, RESET_PASSWORD
+    }
+}

--- a/src/main/java/com/househub/backend/domain/auth/dto/SendEmailResDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/SendEmailResDto.java
@@ -1,0 +1,14 @@
+package com.househub.backend.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SendEmailResDto {
+    private String authCode;
+}

--- a/src/main/java/com/househub/backend/domain/auth/dto/SendEmailResDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/SendEmailResDto.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class SendEmailResDto {
-    private String authCode;
+	private String expiresAt; // 서버에서 반환된 만료 시간
 }

--- a/src/main/java/com/househub/backend/domain/auth/dto/SignUpReqDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/SignUpReqDto.java
@@ -2,12 +2,17 @@ package com.househub.backend.domain.auth.dto;
 
 import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.agent.entity.RealEstate;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
@@ -15,106 +20,106 @@ import lombok.*;
 @Builder
 public class SignUpReqDto {
 
-    @Valid
-    private AgentDto agent; // 공인중개사 정보
+	@Valid
+	private AgentDto agent; // 공인중개사 정보
 
-    @Valid
-    private RealEstateDto realEstate; // 부동산 정보 (선택값)
+	@Valid
+	private RealEstateDto realEstate; // 부동산 정보 (선택값)
 
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class AgentDto {
-        @NotBlank(message = "이름을 입력하세요.")
-        private String name;
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class AgentDto {
+		@NotBlank(message = "이름을 입력하세요.")
+		private String name;
 
-        @Pattern(regexp = "^(서울|부산|대구|인천|광주|대전|울산|세종|경기|강원|충북|충남|전북|전남|경북|경남|제주)-(\\d{4})-(\\d{5})$", message = "잘못된 자격증 번호 형식입니다. (예: 123-45-67890)")
-        private String licenseNumber; // 선택값
+		@Pattern(regexp = "^(서울|부산|대구|인천|광주|대전|울산|세종|경기|강원|충북|충남|전북|전남|경북|경남|제주)-(\\d{4})-(\\d{5})$", message = "잘못된 자격증 번호 형식입니다. (예: 123-45-67890)")
+		private String licenseNumber; // 선택값
 
-        @NotBlank(message = "이메일을 입력해주세요.")
-        @Email(message = "잘못된 이메일 형식입니다.")
-        private String email;
+		@NotBlank(message = "이메일을 입력해주세요.")
+		@Email(message = "잘못된 이메일 형식입니다.")
+		private String email;
 
-        @NotBlank(message = "비밀번호를 입력해주세요.")
-        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
-        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$", message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
-        private String password;
+		@NotBlank(message = "비밀번호를 입력해주세요.")
+		@Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+		@Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$", message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
+		private String password;
 
-        @NotBlank(message = "연락처를 입력해주세요.")
-        @Pattern(regexp = "\\d{3}-\\d{4}-\\d{4}", message = "잘못된 연락처 형식입니다. (예: 010-1234-5678)")
-        private String contact;
+		@NotBlank(message = "연락처를 입력해주세요.")
+		@Pattern(regexp = "\\d{3}-\\d{4}-\\d{4}", message = "잘못된 연락처 형식입니다. (예: 010-1234-5678)")
+		private String contact;
 
-        private boolean isEmailVerified;
+		private boolean isEmailVerified; // 이메일 인증 여부, 필수, 반드시 true 여야 회원가입 가능.
 
-        public Agent toAgentEntity(RealEstate realEstate) {
-            return Agent.builder()
-                    .name(name)
-                    .licenseNumber(licenseNumber)
-                    .email(email)
-                    .password(password)
-                    .contact(contact)
-                    .realEstate(realEstate)
-                    .build();
-        }
+		public Agent toAgentEntity(RealEstate realEstate) {
+			return Agent.builder()
+				.name(name)
+				.licenseNumber(licenseNumber)
+				.email(email)
+				.password(password)
+				.contact(contact)
+				.realEstate(realEstate)
+				.build();
+		}
 
-        @Override
-        public String toString() {
-            return "AgentDTO{" +
-                    "name='" + name + '\'' +
-                    ", licenseNumber='" + licenseNumber + '\'' +
-                    ", email='" + email + '\'' +
-                    ", password='" + password + '\'' +
-                    ", contact='" + contact + '\'' +
-                    '}';
-        }
-    }
+		@Override
+		public String toString() {
+			return "AgentDTO{" +
+				"name='" + name + '\'' +
+				", licenseNumber='" + licenseNumber + '\'' +
+				", email='" + email + '\'' +
+				", password='" + password + '\'' +
+				", contact='" + contact + '\'' +
+				'}';
+		}
+	}
 
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class RealEstateDto {
-        private String name; // 선택값
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class RealEstateDto {
+		private String name; // 선택값
 
-        @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "잘못된 사업자 등록번호 형식입니다. (예: 123-45-67890)")
-        private String businessRegistrationNumber; // 선택값
+		@Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "잘못된 사업자 등록번호 형식입니다. (예: 123-45-67890)")
+		private String businessRegistrationNumber; // 선택값
 
-        private String address; // 선택값
+		private String address; // 선택값
 
-        private String roadAddress; // 선택값
+		private String roadAddress; // 선택값
 
-        @Pattern(regexp = "\\d{2,3}-\\d{3,4}-\\d{4}", message = "잘못된 연락처 형식입니다. (예: 02-1234-5678)")
-        private String contact;
+		@Pattern(regexp = "\\d{2,3}-\\d{3,4}-\\d{4}", message = "잘못된 연락처 형식입니다. (예: 02-1234-5678)")
+		private String contact;
 
-        @Override
-        public String toString() {
-            return "RealEstateDTO{" +
-                    "name='" + name + '\'' +
-                    ", businessRegistrationNumber='" + businessRegistrationNumber + '\'' +
-                    ", address='" + address + '\'' +
-                    ", roadAddress='" + roadAddress + '\'' +
-                    ", contact='" + contact + '\'' +
-                    '}';
-        }
+		@Override
+		public String toString() {
+			return "RealEstateDTO{" +
+				"name='" + name + '\'' +
+				", businessRegistrationNumber='" + businessRegistrationNumber + '\'' +
+				", address='" + address + '\'' +
+				", roadAddress='" + roadAddress + '\'' +
+				", contact='" + contact + '\'' +
+				'}';
+		}
 
-        public RealEstate toRealEstateEntity() {
-            return RealEstate.builder()
-                    .name(name)
-                    .businessRegistrationNumber(businessRegistrationNumber)
-                    .address(address)
-                    .roadAddress(roadAddress)
-                    .contact(contact)
-                    .build();
-        }
-    }
+		public RealEstate toRealEstateEntity() {
+			return RealEstate.builder()
+				.name(name)
+				.businessRegistrationNumber(businessRegistrationNumber)
+				.address(address)
+				.roadAddress(roadAddress)
+				.contact(contact)
+				.build();
+		}
+	}
 
-    @Override
-    public String toString() {
-        return "SignUpRequest{" +
-                "agent=" + agent +
-                ", realEstate=" + realEstate +
-                '}';
-    }
+	@Override
+	public String toString() {
+		return "SignUpRequest{" +
+			"agent=" + agent +
+			", realEstate=" + realEstate +
+			'}';
+	}
 }

--- a/src/main/java/com/househub/backend/domain/auth/dto/VerifyEmailReqDto.java
+++ b/src/main/java/com/househub/backend/domain/auth/dto/VerifyEmailReqDto.java
@@ -1,0 +1,24 @@
+package com.househub.backend.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifyEmailReqDto {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "잘못된 이메일 형식입니다.")
+    private String email;
+
+    @NotBlank(message = "인증번호를 입력해주세요.")
+    @Pattern(regexp = "^[0-9]{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
+    private String code;
+}

--- a/src/main/java/com/househub/backend/domain/auth/service/AuthCode.java
+++ b/src/main/java/com/househub/backend/domain/auth/service/AuthCode.java
@@ -1,0 +1,8 @@
+package com.househub.backend.domain.auth.service;
+
+public interface AuthCode {
+    String generateAuthCode();
+    void saveAuthCode(String email, String authCode);
+    String getAuthCode(String email);
+    void deleteAuthCode(String email);
+}

--- a/src/main/java/com/househub/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/househub/backend/domain/auth/service/AuthService.java
@@ -5,6 +5,15 @@ import com.househub.backend.domain.auth.dto.SignInResDto;
 import com.househub.backend.domain.auth.dto.SignUpReqDto;
 
 public interface AuthService {
-    void signup(SignUpReqDto request);
-    SignInResDto signin(SignInReqDto request);
+	void signup(SignUpReqDto request);
+
+	SignInResDto signin(SignInReqDto request);
+
+	public String generateAndSaveAuthCode(String email);
+
+	public String getAuthCode(String email);
+
+	public void deleteAuthCode(String email);
+
+	public void verifyCode(String email, String code);
 }

--- a/src/main/java/com/househub/backend/domain/auth/service/impl/AuthCodeImpl.java
+++ b/src/main/java/com/househub/backend/domain/auth/service/impl/AuthCodeImpl.java
@@ -1,0 +1,86 @@
+package com.househub.backend.domain.auth.service.impl;
+
+import com.househub.backend.domain.auth.service.AuthCode;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class AuthCodeImpl implements AuthCode {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public AuthCodeImpl(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 6자리 숫자 조합의 인증 코드 생성
+     *
+     * @return 생성된 인증 코드
+     */
+    @Override
+    public String generateAuthCode() {
+        Random random = new Random();
+        StringBuilder authCode = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            authCode.append(random.nextInt(10));
+        }
+        return authCode.toString();
+    }
+
+    /**
+     * 생성된 인증 코드를 Redis에 저장.
+     *
+     * @param email    사용자 이메일
+     * @param authCode 인증 코드
+     */
+    @Override
+    public void saveAuthCode(String email, String authCode) {
+        redisTemplate.opsForValue().set(email, authCode, 3, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Redis 에서 인증 코드 조회.
+     *
+     * @param email 사용자 이메일
+     * @return 조회된 인증 코드 (null 이면 인증 코드가 존재하지 않음)
+     */
+    @Override
+    public String getAuthCode(String email) {
+        return redisTemplate.opsForValue().get(email);
+    }
+
+    /**
+     * Redis 에서 인증 코드 삭제.
+     *
+     * @param email 사용자 이메일
+     */
+    @Override
+    public void deleteAuthCode(String email) {
+        redisTemplate.delete(email);
+    }
+
+    /**
+     * 인증 코드를 SHA-256 으로 암호화.
+     *
+     * @param authCode 인증 코드
+     * @return 암호화된 인증 코드
+     * @throws RuntimeException 암호화 알고리즘을 찾을 수 없는 경우
+     */
+//    private String encryptAuthCode(String authCode) {
+//        try {
+//            MessageDigest md = MessageDigest.getInstance("SHA-256");
+//            md.update(authCode.getBytes());
+//            byte[] byteData = md.digest();
+//            StringBuilder sb = new StringBuilder();
+//            for (byte byteDatum : byteData) {
+//                sb.append(Integer.toString((byteDatum & 0xff) + 0x100, 16).substring(1));
+//            }
+//            return sb.toString();
+//        } catch (NoSuchAlgorithmException e) {
+//            throw new RuntimeException(e);
+//        }
+//    }
+}

--- a/src/main/java/com/househub/backend/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/auth/service/impl/AuthServiceImpl.java
@@ -258,6 +258,12 @@ public class AuthServiceImpl implements AuthService {
 		authCode.deleteAuthCode(email);
 	}
 
+	/**
+	 * 인증 코드를 검증합니다.
+	 *
+	 * @param email 사용자 이메일
+	 * @param code  인증 코드
+	 */
 	@Transactional
 	@Override
 	public void verifyCode(String email, String code) {

--- a/src/test/java/com/househub/backend/domain/auth/service/AgentSignUpServiceTest.java
+++ b/src/test/java/com/househub/backend/domain/auth/service/AgentSignUpServiceTest.java
@@ -1,13 +1,11 @@
 package com.househub.backend.domain.auth.service;
 
-import com.househub.backend.common.exception.AlreadyExistsException;
-import com.househub.backend.domain.agent.entity.Agent;
-import com.househub.backend.domain.agent.entity.RealEstate;
-import com.househub.backend.domain.agent.repository.AgentRepository;
-import com.househub.backend.domain.auth.dto.SignUpReqDto;
-import com.househub.backend.domain.auth.exception.EmailVerifiedException;
-import com.househub.backend.domain.auth.service.impl.AuthServiceImpl;
-import com.househub.backend.domain.realEstate.repository.RealEstateRepository;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,124 +15,122 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import com.househub.backend.common.exception.AlreadyExistsException;
+import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.agent.entity.RealEstate;
+import com.househub.backend.domain.agent.repository.AgentRepository;
+import com.househub.backend.domain.auth.dto.SignUpReqDto;
+import com.househub.backend.domain.auth.exception.EmailVerifiedException;
+import com.househub.backend.domain.auth.service.impl.AuthServiceImpl;
+import com.househub.backend.domain.realEstate.repository.RealEstateRepository;
 
 @ExtendWith(MockitoExtension.class)
 public class AgentSignUpServiceTest {
-    @Mock
-    private AgentRepository agentRepository;
+	@Mock
+	private AgentRepository agentRepository;
 
-    @Mock
-    private RealEstateRepository realEstateRepository;
+	@Mock
+	private RealEstateRepository realEstateRepository;
 
-    @Mock
-    private PasswordEncoder passwordEncoder;
+	@Mock
+	private PasswordEncoder passwordEncoder;
 
-    @InjectMocks
-    private AuthServiceImpl authService;
+	@InjectMocks
+	private AuthServiceImpl authService;
 
-    private SignUpReqDto request;
-    private SignUpReqDto.AgentDto agentDto;
+	private SignUpReqDto request;
+	private SignUpReqDto.AgentDto agentDto;
 
-    // 테스트에 필요한 데이터 초기화
-    @BeforeEach
-    void setup() {
-        agentDto = SignUpReqDto.AgentDto.builder()
-                .name("박공일")
-                .licenseNumber("서울-2023-12345")
-                .email("gongil@example.com")
-                .password("password123!")
-                .contact("010-1234-5678")
-                .isEmailVerified(true) // 이메일 인증 여부 설정
-                .build();
+	// 테스트에 필요한 데이터 초기화
+	@BeforeEach
+	void setup() {
+		agentDto = SignUpReqDto.AgentDto.builder()
+			.name("박공일")
+			.licenseNumber("서울-2023-12345")
+			.email("gongil@example.com")
+			.password("password123!")
+			.contact("010-1234-5678")
+			.isEmailVerified(true) // 이메일 인증 여부 설정
+			.build();
 
-        SignUpReqDto.RealEstateDto realEstateDto = SignUpReqDto.RealEstateDto.builder()
-                .name("테스트 부동산")
-                .businessRegistrationNumber("123-45-67890")
-                .address("테스트 주소")
-                .roadAddress("테스트 도로명 주소")
-                .contact("02-1234-5678")
-                .build();
+		SignUpReqDto.RealEstateDto realEstateDto = SignUpReqDto.RealEstateDto.builder()
+			.name("테스트 부동산")
+			.businessRegistrationNumber("123-45-67890")
+			.address("테스트 주소")
+			.roadAddress("테스트 도로명 주소")
+			.contact("02-1234-5678")
+			.build();
 
-        request = SignUpReqDto.builder()
-                .agent(agentDto)
-                .realEstate(realEstateDto)
-                .build();
-    }
+		request = SignUpReqDto.builder()
+			.agent(agentDto)
+			.realEstate(realEstateDto)
+			.build();
+	}
 
-    @Test
-<<<<<<< HEAD:src/test/java/com/househub/backend/domain/auth/service/AgentSignUpServiceTest.java
-    @DisplayName("회원가입 실패 - 이메일 미인증")
-    void signup_fail_email_not_verified() {
-        // 이메일 인증되지 않은 경우
-        agentDto.setEmailVerified(false);
+	@Test
+	@DisplayName("회원가입 실패 - 이메일 미인증")
+	void signup_fail_email_not_verified() {
+		// 이메일 인증되지 않은 경우
+		agentDto.setEmailVerified(false);
 
-        // 이메일 인증되지 않았을 때 예외가 발생하는지 확인
-        assertThrows(EmailVerifiedException.class, () -> authService.signup(request));
+		// 이메일 인증되지 않았을 때 예외가 발생하는지 확인
+		assertThrows(EmailVerifiedException.class, () -> authService.signup(request));
 
-        // 아무것도 호출되지 않았는지 검증
-        verify(agentRepository, never()).findByEmail(any());
-        verify(realEstateRepository, never()).findByBusinessRegistrationNumber(any());
-        verify(realEstateRepository, never()).save(any());
-        verify(agentRepository, never()).save(any());
-    }
+		// 아무것도 호출되지 않았는지 검증
+		verify(agentRepository, never()).findByEmail(any());
+		verify(realEstateRepository, never()).findByBusinessRegistrationNumber(any());
+		verify(realEstateRepository, never()).save(any());
+		verify(agentRepository, never()).save(any());
+	}
 
-    @Test
-    @DisplayName("회원가입 실패 - 이메일 중복")
-    void signup_fail_email_duplicate() {
-        // 이메일 중복 검사를 위해 이미 존재하는 이메일 반환
-        when(agentRepository.findByEmail(any())).thenReturn(Optional.of(Agent.builder().email("gongil@example.com").build()));
+	@Test
+	@DisplayName("회원가입 실패 - 이메일 중복")
+	void signup_fail_email_duplicate() {
+		// 이메일 중복 검사를 위해 이미 존재하는 이메일 반환
+		when(agentRepository.findByEmail(any())).thenReturn(
+			Optional.of(Agent.builder().email("gongil@example.com").build()));
 
-        // 이메일 중복 예외 발생 확인
-        assertThrows(AlreadyExistsException.class, () -> authService.signup(request));
+		// 이메일 중복 예외 발생 확인
+		assertThrows(AlreadyExistsException.class, () -> authService.signup(request));
 
-        // agentrepository.findByEmail 호출되었는지 검증
-        verify(agentRepository, times(1)).findByEmail(any());
-        verify(realEstateRepository, never()).findByBusinessRegistrationNumber(any());
-        verify(realEstateRepository, never()).save(any());
-        verify(agentRepository, never()).save(any());
-    }
+		// agentrepository.findByEmail 호출되었는지 검증
+		verify(agentRepository, times(1)).findByEmail(any());
+		verify(realEstateRepository, never()).findByBusinessRegistrationNumber(any());
+		verify(realEstateRepository, never()).save(any());
+		verify(agentRepository, never()).save(any());
+	}
 
-    @Test
-    @DisplayName("회원가입 성공")
-    void signup_success() {
-        // 정상적인 회원가입
-        when(agentRepository.findByEmail(any())).thenReturn(Optional.empty());
-=======
-    void 회원가입_성공() {
-        // 자격증 번호와 사업자 등록 번호가 중복되지 않는 경우
-        // 모킹된 리포지토리의 동작을 미리 정의한 것.
-        when(agentRepository.findByLicenseNumber(any())).thenReturn(Optional.empty());
->>>>>>> b8423d5 (byungchan, feat: 인증 메일 발송 및 인증번호 처리 API 구현 with Redis #23):src/test/java/com/househub/backend/domain/auth/service/AuthServiceImplTest.java
-        when(realEstateRepository.findByBusinessRegistrationNumber(any())).thenReturn(Optional.empty());
-        when(realEstateRepository.save(any())).thenReturn(RealEstate.builder().build());
-        when(agentRepository.save(any())).thenReturn(Agent.builder().build());
+	@Test
+	@DisplayName("회원가입 성공")
+	void signup_success() {
+		// 정상적인 회원가입
+		when(agentRepository.findByEmail(any())).thenReturn(Optional.empty());
+		when(realEstateRepository.findByBusinessRegistrationNumber(any())).thenReturn(Optional.empty());
+		when(realEstateRepository.save(any())).thenReturn(RealEstate.builder().build());
+		when(agentRepository.save(any())).thenReturn(Agent.builder().build());
 
-        authService.signup(request);
+		authService.signup(request);
 
-        // 각 리포지토리 메서드가 예상되로 호출되었는지 검증
-        verify(agentRepository, times(1)).findByEmail(any());
-        verify(realEstateRepository, times(1)).save(any());
-        verify(agentRepository, times(1)).save(any());
-    }
+		// 각 리포지토리 메서드가 예상되로 호출되었는지 검증
+		verify(agentRepository, times(1)).findByEmail(any());
+		verify(realEstateRepository, times(1)).save(any());
+		verify(agentRepository, times(1)).save(any());
+	}
 
-    @Test
-    @DisplayName("회원가입 실패 - 자격증번호 중복")
-    void signup_fail_licensenumber_duplicate() {
-        // 자격증 번호를 선택적으로 입력했는데 이미 존재하는 경우
-        when(agentRepository.findByLicenseNumber(any())).thenReturn(Optional.of(Agent.builder().licenseNumber("서울-2023-12345").build()));
+	@Test
+	@DisplayName("회원가입 실패 - 자격증번호 중복")
+	void signup_fail_licensenumber_duplicate() {
+		// 자격증 번호를 선택적으로 입력했는데 이미 존재하는 경우
+		when(agentRepository.findByLicenseNumber(any())).thenReturn(
+			Optional.of(Agent.builder().licenseNumber("서울-2023-12345").build()));
 
-        // AlreadyExistException 예외 발생했는지 검증
-        assertThrows(AlreadyExistsException.class, () -> authService.signup(request));
+		// AlreadyExistException 예외 발생했는지 검증
+		assertThrows(AlreadyExistsException.class, () -> authService.signup(request));
 
-        // 자격증 번호 중복 확인 메서드만 호출되었는지 검증
-        verify(agentRepository, times(1)).findByLicenseNumber(any());
-        verify(realEstateRepository, never()).findByBusinessRegistrationNumber(any());
-        verify(realEstateRepository, never()).save(any());
-        verify(agentRepository, never()).save(any());
-    }
+		// 자격증 번호 중복 확인 메서드만 호출되었는지 검증
+		verify(agentRepository, times(1)).findByLicenseNumber(any());
+		verify(realEstateRepository, never()).findByBusinessRegistrationNumber(any());
+		verify(realEstateRepository, never()).save(any());
+		verify(agentRepository, never()).save(any());
+	}
 }

--- a/src/test/java/com/househub/backend/domain/auth/service/AgentSignUpServiceTest.java
+++ b/src/test/java/com/househub/backend/domain/auth/service/AgentSignUpServiceTest.java
@@ -67,6 +67,7 @@ public class AgentSignUpServiceTest {
     }
 
     @Test
+<<<<<<< HEAD:src/test/java/com/househub/backend/domain/auth/service/AgentSignUpServiceTest.java
     @DisplayName("회원가입 실패 - 이메일 미인증")
     void signup_fail_email_not_verified() {
         // 이메일 인증되지 않은 경우
@@ -103,6 +104,12 @@ public class AgentSignUpServiceTest {
     void signup_success() {
         // 정상적인 회원가입
         when(agentRepository.findByEmail(any())).thenReturn(Optional.empty());
+=======
+    void 회원가입_성공() {
+        // 자격증 번호와 사업자 등록 번호가 중복되지 않는 경우
+        // 모킹된 리포지토리의 동작을 미리 정의한 것.
+        when(agentRepository.findByLicenseNumber(any())).thenReturn(Optional.empty());
+>>>>>>> b8423d5 (byungchan, feat: 인증 메일 발송 및 인증번호 처리 API 구현 with Redis #23):src/test/java/com/househub/backend/domain/auth/service/AuthServiceImplTest.java
         when(realEstateRepository.findByBusinessRegistrationNumber(any())).thenReturn(Optional.empty());
         when(realEstateRepository.save(any())).thenReturn(RealEstate.builder().build());
         when(agentRepository.save(any())).thenReturn(Agent.builder().build());


### PR DESCRIPTION
## 📌 PR 목적 및 내용
인증 메일 발송 및 인증번호 확인 API 변경

## ✏️ 변경 사항
- 인증 메일 발송 API 응답 데이터로 세션 만료 기한 추가
- 아직 이메일 발송 서비스 연동 전이어서 생성된 인증번호는 로그로 확인 가능
- 인증 메일 발송 및 인증번호 확인 API 인증되지 않은 사용자 접근 가능하도록 설정

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈
- #23 
- #56 
