### PR TITLE
byungchan, feature: 공유 토큰으로 문의 템플릿 조회 및 고객 문의 등록 API 구현

### DIFF
--- a/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
@@ -45,6 +45,7 @@ public class WebSecurityConfig {
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.authorizeHttpRequests((authz) -> authz
 				.requestMatchers(
+					"/api/inquiry-templates/share/**",
 					"/api/auth/session",
 					"/api/auth/email/**",
 					"/api/auth/signup",

--- a/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/househub/backend/common/config/WebSecurityConfig.java
@@ -46,6 +46,7 @@ public class WebSecurityConfig {
 			.authorizeHttpRequests((authz) -> authz
 				.requestMatchers(
 					"/api/inquiry-templates/share/**",
+					"/api/inquiries",
 					"/api/auth/session",
 					"/api/auth/email/**",
 					"/api/auth/signup",

--- a/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.househub.backend.common.response.ErrorResponse;
+import com.househub.backend.domain.inquiry.exception.InvalidAnswerFormatException;
+import com.househub.backend.domain.inquiry.exception.QuestionNotFoundException;
 
 import io.swagger.v3.oas.annotations.Hidden;
 
@@ -39,17 +41,6 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
 	}
-
-	// @ExceptionHandler(ValidationFailedException.class)
-	// public ResponseEntity<ErrorResponse> handleValidationFailedException(ValidationFailedException ex) {
-	// 	ErrorResponse errorResponse = ErrorResponse.builder()
-	// 		.success(false)
-	// 		.message(ex.getMessage())
-	// 		.code(ex.getCode())
-	// 		.errors(ex.getFieldErrors())
-	// 		.build();
-	// 	return ResponseEntity.badRequest().body(errorResponse);
-	// }
 
 	// 유효성 검사 실패 예외 처리
 	@ExceptionHandler(MethodArgumentNotValidException.class)
@@ -122,5 +113,27 @@ public class GlobalExceptionHandler {
 
 		// HTTP 응답으로 반환
 		return ResponseEntity.badRequest().body(errorResponse);
+	}
+
+	@ExceptionHandler(QuestionNotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleQuestionNotFound(QuestionNotFoundException e) {
+		ErrorResponse response = ErrorResponse.builder()
+			.success(false)
+			.message(e.getMessage())
+			.code(e.getCode())
+			.errors(null)
+			.build();
+		return ResponseEntity.badRequest().body(response);
+	}
+
+	@ExceptionHandler(InvalidAnswerFormatException.class)
+	public ResponseEntity<ErrorResponse> handleInvalidAnswerFormat(InvalidAnswerFormatException e) {
+		ErrorResponse response = ErrorResponse.builder()
+			.success(false)
+			.message(e.getMessage())
+			.code(e.getCode())
+			.errors(null)
+			.build();
+		return ResponseEntity.badRequest().body(response);
 	}
 }

--- a/src/main/java/com/househub/backend/domain/customer/entity/CustomerCandidate.java
+++ b/src/main/java/com/househub/backend/domain/customer/entity/CustomerCandidate.java
@@ -1,0 +1,44 @@
+package com.househub.backend.domain.customer.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 아직 고객으로 확정되지 않은 문의자 정보 임시 저장
+@Entity
+@Table(name = "customer_candidates")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CustomerCandidate {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 50)
+	private String name;
+
+	@Column(nullable = false)
+	private String email;
+
+	@Column(nullable = false)
+	private String contact;
+
+	public static CustomerCandidate create(String name, String email, String phone) {
+		return CustomerCandidate.builder()
+			.name(name)
+			.email(email)
+			.contact(phone)
+			.build();
+	}
+}

--- a/src/main/java/com/househub/backend/domain/customer/repository/CustomerCandidateRepository.java
+++ b/src/main/java/com/househub/backend/domain/customer/repository/CustomerCandidateRepository.java
@@ -1,0 +1,11 @@
+package com.househub.backend.domain.customer.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.househub.backend.domain.customer.entity.CustomerCandidate;
+
+public interface CustomerCandidateRepository extends JpaRepository<CustomerCandidate, Long> {
+	Optional<CustomerCandidate> findByEmailAndContact(String email, String phone);
+}

--- a/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepository.java
@@ -12,9 +12,11 @@ import com.househub.backend.domain.customer.entity.Customer;
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
-    Optional<Customer> findByEmail(String email);
+	Optional<Customer> findByEmail(String email);
 
-    List<Customer> findAllByAgentAndDeletedAtIsNull(Agent agent);
+	List<Customer> findAllByAgentAndDeletedAtIsNull(Agent agent);
 
-    Optional<Customer> findByIdAndAgentAndDeletedAtIsNull(Long id, Agent agent);
+	Optional<Customer> findByIdAndAgentAndDeletedAtIsNull(Long id, Agent agent);
+
+	Optional<Customer> findByEmailAndContact(String email, String phone);
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/controller/InquiryController.java
@@ -1,0 +1,48 @@
+package com.househub.backend.domain.inquiry.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.househub.backend.common.response.SuccessResponse;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryReqDto;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryResDto;
+import com.househub.backend.domain.inquiry.service.InquiryService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+	private final InquiryService inquiryService;
+
+	/**
+	 * 고객 문의를 등록합니다.
+	 *
+	 * @param reqDto 문의 등록 요청
+	 * @return 생성된 문의 응답
+	 */
+	@Operation(summary = "문의 등록", description = "고객이 남긴 문의를 등록합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "문의 등록 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+		@ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+	})
+	@PostMapping
+	public ResponseEntity<SuccessResponse<CreateInquiryResDto>> createInquiry(
+		@Valid @RequestBody CreateInquiryReqDto reqDto
+	) {
+		CreateInquiryResDto response = inquiryService.createInquiry(reqDto);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(SuccessResponse.success("문의가 성공적으로 등록되었습니다", "INQUIRY_CREATE_SUCCESS", response));
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryReqDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryReqDto.java
@@ -1,0 +1,43 @@
+package com.househub.backend.domain.inquiry.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateInquiryReqDto {
+
+	@NotBlank
+	private String templateToken;
+
+	@NotBlank
+	private String name;
+
+	@Email
+	private String email;
+
+	@NotBlank
+	private String phone;
+
+	@NotEmpty
+	private List<AnswerDto> answers;
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class AnswerDto {
+		private Long questionId;
+		private Object answerText; // String, List<String> 모두 가능
+	}
+}
+

--- a/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryResDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryResDto.java
@@ -1,0 +1,12 @@
+package com.househub.backend.domain.inquiry.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CreateInquiryResDto {
+	private Long inquiryId;
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/entity/Inquiry.java
@@ -1,0 +1,65 @@
+package com.househub.backend.domain.inquiry.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.customer.entity.CustomerCandidate;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "inquiries")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Inquiry {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 어떤 템플릿을 기준으로 문의가 작성되었는지
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "template_id")
+	private InquiryTemplate template;
+
+	// 기존 고객과 매핑되는 경우
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "customer_id")
+	private Customer customer; // null 허용
+
+	// 아직 고객 등록되지 않은 임시 문의자
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "customer_candidate_id")
+	private CustomerCandidate candidate; // null 허용
+
+	// 문의 항목에 대한 실제 답변 리스트
+	@OneToMany(mappedBy = "inquiry", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<InquiryAnswer> answers = new ArrayList<>();
+
+	private LocalDateTime createdAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/entity/InquiryAnswer.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/entity/InquiryAnswer.java
@@ -1,0 +1,45 @@
+package com.househub.backend.domain.inquiry.entity;
+
+import com.househub.backend.domain.inquiryTemplate.entity.Question;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "inquiry_answers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class InquiryAnswer {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 어떤 문의에 대한 답변인지
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "inquiry_id")
+	private Inquiry inquiry;
+
+	// 어떤 질문에 대한 답변인지
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "question_id")
+	private Question question;
+
+	// answer 는 다양한 타입을 담을 수 있도록 JSON 문자열로 저장
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String answer;
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/exception/InvalidAnswerFormatException.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/exception/InvalidAnswerFormatException.java
@@ -1,0 +1,17 @@
+package com.househub.backend.domain.inquiry.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import lombok.Getter;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+@Getter
+public class InvalidAnswerFormatException extends RuntimeException {
+	private final String code;
+
+	public InvalidAnswerFormatException() {
+		super("답변 형식이 올바르지 않습니다.");
+		this.code = "INVALID_ANSWER_FORMAT";
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/exception/QuestionNotFoundException.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/exception/QuestionNotFoundException.java
@@ -1,0 +1,17 @@
+package com.househub.backend.domain.inquiry.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import lombok.Getter;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+@Getter
+public class QuestionNotFoundException extends RuntimeException {
+	private final String code;
+
+	public QuestionNotFoundException(Long questionId) {
+		super("해당 질문을 찾을 수 없습니다. (id: " + questionId + ")");
+		this.code = "QUESTION_NOT_FOUND";
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/repository/InquiryAnswerRepository.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/repository/InquiryAnswerRepository.java
@@ -1,0 +1,10 @@
+package com.househub.backend.domain.inquiry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.househub.backend.domain.inquiry.entity.InquiryAnswer;
+
+@Repository
+public interface InquiryAnswerRepository extends JpaRepository<InquiryAnswer, Long> {
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/repository/InquiryRepository.java
@@ -1,0 +1,10 @@
+package com.househub.backend.domain.inquiry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.househub.backend.domain.inquiry.entity.Inquiry;
+
+@Repository
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/InquiryService.java
@@ -1,0 +1,8 @@
+package com.househub.backend.domain.inquiry.service;
+
+import com.househub.backend.domain.inquiry.dto.CreateInquiryReqDto;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryResDto;
+
+public interface InquiryService {
+	CreateInquiryResDto createInquiry(CreateInquiryReqDto reqDto);
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryServiceImpl.java
@@ -1,0 +1,128 @@
+package com.househub.backend.domain.inquiry.service.impl;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.househub.backend.common.exception.ResourceNotFoundException;
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.customer.entity.CustomerCandidate;
+import com.househub.backend.domain.customer.repository.CustomerCandidateRepository;
+import com.househub.backend.domain.customer.repository.CustomerRepository;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryReqDto;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryResDto;
+import com.househub.backend.domain.inquiry.entity.Inquiry;
+import com.househub.backend.domain.inquiry.entity.InquiryAnswer;
+import com.househub.backend.domain.inquiry.exception.InvalidAnswerFormatException;
+import com.househub.backend.domain.inquiry.exception.QuestionNotFoundException;
+import com.househub.backend.domain.inquiry.repository.InquiryAnswerRepository;
+import com.househub.backend.domain.inquiry.repository.InquiryRepository;
+import com.househub.backend.domain.inquiry.service.InquiryService;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplateSharedToken;
+import com.househub.backend.domain.inquiryTemplate.entity.Question;
+import com.househub.backend.domain.inquiryTemplate.repository.InquiryTemplateRepository;
+import com.househub.backend.domain.inquiryTemplate.repository.InquiryTemplateSharedTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryServiceImpl implements InquiryService {
+	private final InquiryTemplateRepository templateRepository;
+	private final InquiryTemplateSharedTokenRepository sharedTokenRepository;
+	private final InquiryRepository inquiryRepository;
+	private final InquiryAnswerRepository inquiryAnswerRepository;
+	private final CustomerRepository customerRepository;
+	private final CustomerCandidateRepository customerCandidateRepository;
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * 문의를 생성합니다.
+	 *
+	 * @param reqDto 문의 생성 요청 DTO
+	 * @return 문의 생성 응답 DTO
+	 */
+	@Transactional
+	@Override
+	public CreateInquiryResDto createInquiry(CreateInquiryReqDto reqDto) {
+		// templateToken 으로 InquiryTemplateShareToken 엔티티 조회
+		InquiryTemplateSharedToken shareToken = sharedTokenRepository.findByShareTokenAndActiveTrue(
+				reqDto.getTemplateToken())
+			.orElseThrow(() -> new ResourceNotFoundException("유효하지 않은 문의 템플릿 링크입니다.", "TEMPLATE_NOT_FOUND"));
+
+		InquiryTemplate template = shareToken.getTemplate();
+
+		if (template.getQuestions().isEmpty()) {
+			throw new ResourceNotFoundException("문의 템플릿에 질문이 존재하지 않습니다.", "TEMPLATE_QUESTION_NOT_FOUND");
+		}
+
+		// 문의 남긴 고객이 DB 에 존재하는지 확인
+		Optional<Customer> optCustomer = customerRepository.findByEmailAndContact(reqDto.getEmail(), reqDto.getPhone());
+
+		// 고객이 DB에 존재하지 않는 경우, 고객 후보로 저장
+		// 고객 후보는 고객과 1:1 관계이므로, 고객이 존재하지 않는 경우에만 저장
+		CustomerCandidate candidate = null;
+		if (optCustomer.isEmpty()) {
+			candidate = customerCandidateRepository
+				.findByEmailAndContact(reqDto.getEmail(), reqDto.getPhone())
+				.orElseGet(() -> customerCandidateRepository.save(
+					CustomerCandidate.builder()
+						.name(reqDto.getName())
+						.email(reqDto.getEmail())
+						.contact(reqDto.getPhone())
+						.build()
+				));
+		}
+
+		// 문의 생성
+		Inquiry inquiry = inquiryRepository.save(
+			Inquiry.builder()
+				.template(template)
+				.customer(optCustomer.orElse(null))
+				.candidate(candidate)
+				.build()
+		);
+
+		// 질문 목록 캐싱
+		Map<Long, Question> questionMap = template.getQuestions().stream()
+			.collect(Collectors.toMap(Question::getId, Function.identity()));
+
+		// 답변 저장
+		for (CreateInquiryReqDto.AnswerDto answerDto : reqDto.getAnswers()) {
+			Question question = questionMap.get(answerDto.getQuestionId());
+
+			if (question == null)
+				throw new QuestionNotFoundException(answerDto.getQuestionId());
+
+			String serializedAnswer;
+			try {
+				if (answerDto.getAnswerText() instanceof String) {
+					serializedAnswer = (String)answerDto.getAnswerText();
+				} else {
+					serializedAnswer = objectMapper.writeValueAsString(answerDto.getAnswerText());
+				}
+			} catch (JsonProcessingException e) {
+				throw new InvalidAnswerFormatException();
+			}
+
+			InquiryAnswer answer = InquiryAnswer.builder()
+				.inquiry(inquiry)
+				.question(question)
+				.answer(serializedAnswer)
+				.build();
+
+			inquiryAnswerRepository.save(answer);
+		}
+
+		return CreateInquiryResDto.builder()
+			.inquiryId(inquiry.getId())
+			.build();
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/dto/InquiryQuestionResDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/dto/InquiryQuestionResDto.java
@@ -1,0 +1,47 @@
+package com.househub.backend.domain.inquiryTemplate.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.househub.backend.domain.inquiryTemplate.entity.Question;
+import com.househub.backend.domain.inquiryTemplate.entity.QuestionType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InquiryQuestionResDto {
+	private Long id;
+	private String label;
+	private QuestionType type;
+
+	@JsonProperty("isRequired")
+	private Boolean required;
+
+	private List<String> options;
+	private int questionOrder;
+
+	public static InquiryQuestionResDto fromEntity(Question question) {
+		return InquiryQuestionResDto.builder()
+			.id(question.getId())
+			.label(question.getLabel())
+			.type(question.getType())
+			.required(question.getRequired())
+			.options(question.getOptions())
+			.questionOrder(question.getQuestionOrder())
+			.build();
+	}
+
+	public static List<InquiryQuestionResDto> fromEntities(List<Question> questions) {
+		return questions.stream()
+			.map(InquiryQuestionResDto::fromEntity)
+			.toList();
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/dto/InquiryTemplateResDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/dto/InquiryTemplateResDto.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
-import com.househub.backend.domain.inquiryTemplate.entity.QuestionType;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +15,7 @@ public class InquiryTemplateResDto {
 	private Long id;
 	private String name;
 	private String description;
-	private List<QuestionDto> questions;
+	private List<InquiryQuestionResDto> questions;
 	@JsonProperty("isActive")
 	private Boolean active;
 	private LocalDateTime createdAt;
@@ -27,36 +26,11 @@ public class InquiryTemplateResDto {
 			.id(entity.getId())
 			.name(entity.getName())
 			.description(entity.getDescription())
-			.questions(entity.getQuestions().stream()
-				.map(question -> QuestionDto.builder()
-					.id(question.getId())
-					.label(question.getLabel())
-					.type(question.getType())
-					.required(question.getRequired())
-					.options(question.getOptions())
-					.questionOrder(question.getQuestionOrder())
-					.build())
-				.toList())
+			.questions(InquiryQuestionResDto.fromEntities(entity.getQuestions()))
 			.active(entity.getActive())
 			.createdAt(entity.getCreatedAt())
 			.updatedAt(entity.getUpdatedAt())
 			.build();
-	}
-
-	@Getter
-	@Builder
-	public static class QuestionDto {
-		private Long id;
-
-		private String label;
-
-		private QuestionType type;
-
-		@JsonProperty("isRequired")
-		private Boolean required;
-		private List<String> options;
-
-		private int questionOrder;
 	}
 }
 

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/dto/InquiryTemplateSharedResDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/dto/InquiryTemplateSharedResDto.java
@@ -17,17 +17,15 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class InquiryTemplatePreviewResDto {
-	private Long id;
+public class InquiryTemplateSharedResDto {
 	private String name;
 	private String description;
 	@JsonProperty("isActive")
 	private Boolean active;
 	private List<InquiryQuestionResDto> questions;
 
-	public static InquiryTemplatePreviewResDto fromEntity(InquiryTemplate inquiryTemplate, List<Question> questions) {
-		return InquiryTemplatePreviewResDto.builder()
-			.id(inquiryTemplate.getId())
+	public static InquiryTemplateSharedResDto fromEntity(InquiryTemplate inquiryTemplate, List<Question> questions) {
+		return InquiryTemplateSharedResDto.builder()
 			.name(inquiryTemplate.getName())
 			.description(inquiryTemplate.getDescription())
 			.active(inquiryTemplate.getActive())

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/entity/InquiryTemplate.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/entity/InquiryTemplate.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.househub.backend.domain.agent.entity.RealEstate;
+import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.inquiryTemplate.dto.CreateInquiryTemplateReqDto;
 import com.househub.backend.domain.inquiryTemplate.dto.UpdateInquiryTemplateReqDto;
 
@@ -31,7 +31,7 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "inquiry_templates",
 	uniqueConstraints = {
-		@UniqueConstraint(columnNames = {"real_estate_id", "name"})
+		@UniqueConstraint(columnNames = {"agent_id", "name"})
 	}
 )
 @Getter
@@ -44,8 +44,8 @@ public class InquiryTemplate {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "real_estate_id", nullable = false)
-	private RealEstate realEstate;
+	@JoinColumn(name = "agent_id", nullable = false)
+	private Agent agent;
 
 	@Column(nullable = false)
 	private String name;
@@ -86,9 +86,9 @@ public class InquiryTemplate {
 		this.active = active;
 	}
 
-	public static InquiryTemplate fromDto(CreateInquiryTemplateReqDto reqDto, RealEstate realEstate) {
+	public static InquiryTemplate fromDto(CreateInquiryTemplateReqDto reqDto, Agent agent) {
 		return InquiryTemplate.builder()
-			.realEstate(realEstate)
+			.agent(agent)
 			.name(reqDto.getName())
 			.description(reqDto.getDescription())
 			.active(reqDto.getActive())

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/entity/InquiryTemplateSharedToken.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/entity/InquiryTemplateSharedToken.java
@@ -49,6 +49,7 @@ public class InquiryTemplateSharedToken {
 
 	// 공유 활성화 여부
 	@Column(nullable = false)
+	@Builder.Default
 	private Boolean active = true;
 
 	@PrePersist

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/entity/InquiryTemplateSharedToken.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/entity/InquiryTemplateSharedToken.java
@@ -1,0 +1,81 @@
+package com.househub.backend.domain.inquiryTemplate.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "inquiry_template_shared_tokens")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InquiryTemplateSharedToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 문의 템플릿 참조
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "template_id", nullable = false)
+	private InquiryTemplate template;
+
+	// 공유 토큰 (UUID 등 예측 불가능한 문자열)
+	@Column(name = "share_token", unique = true, nullable = false, length = 36)
+	private String shareToken;
+
+	// 생성 시간
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	// 만료 시간 (nullable 가능)
+	@Column(name = "expired_at")
+	private LocalDateTime expiredAt;
+
+	// 공유 활성화 여부
+	@Column(nullable = false)
+	private Boolean active = true;
+
+	@PrePersist
+	public void prePersist() {
+		this.createdAt = LocalDateTime.now();
+	}
+
+	public static InquiryTemplateSharedToken create(InquiryTemplate template) {
+		return InquiryTemplateSharedToken.builder()
+			.template(template)
+			.shareToken(generateShareToken()) // 예측 불가능한 공유 토큰 생성
+			.active(template.getActive()) // 템플릿의 상태에 따라 활성화 여부 설정
+			.expiredAt(template.getActive() ? LocalDateTime.now().plusMonths(1L) : null) // 활성화된 토큰은 1개월 간 유지
+			.build();
+	}
+
+	/**
+	 * 공유 토큰을 생성하는 메서드
+	 * @return UUID 로 생성된 예측 불가능한 문자열
+	 */
+	private static String generateShareToken() {
+		// UUID 로 예측 불가능한 문자열 생성
+		return UUID.randomUUID().toString();
+	}
+
+	public void setActive(Boolean active) {
+		this.active = active;
+	}
+}
+

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/exception/InactiveTemplateException.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/exception/InactiveTemplateException.java
@@ -1,0 +1,8 @@
+package com.househub.backend.domain.inquiryTemplate.exception;
+
+// 공유된 템플릿이 비활성화되어 더 이상 접근할 수 없는 경우
+public class InactiveTemplateException extends RuntimeException {
+	public InactiveTemplateException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/exception/InvalidShareTokenException.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/exception/InvalidShareTokenException.java
@@ -1,0 +1,8 @@
+package com.househub.backend.domain.inquiryTemplate.exception;
+
+// 공유 토큰이 존재하지 않거나 유효하지 않은 경우
+public class InvalidShareTokenException extends RuntimeException {
+	public InvalidShareTokenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/repository/InquiryTemplateRepository.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/repository/InquiryTemplateRepository.java
@@ -15,38 +15,34 @@ import io.lettuce.core.dynamic.annotation.Param;
 @Repository
 public interface InquiryTemplateRepository extends JpaRepository<InquiryTemplate, Long> {
 
-	// 🔄 findByIdAndRealEstateId
 	@Query("SELECT it FROM InquiryTemplate it " +
 		"WHERE it.deletedAt IS NULL " +
 		"AND it.id = :id " +
-		"AND it.realEstate.id = :realEstateId")
-	Optional<InquiryTemplate> findByIdAndRealEstateId(@Param("id") Long id, @Param("realEstateId") Long realEstateId);
+		"AND it.agent.id = :agentId")
+	Optional<InquiryTemplate> findByIdAndAgentId(@Param("id") Long id, @Param("agentId") Long agentId);
 
-	// 🔄 findAllByRealEstateIdAndFilters
 	@Query("SELECT it FROM InquiryTemplate it " +
 		"WHERE it.deletedAt IS NULL " +
-		"AND it.realEstate.id = :realEstateId " +
+		"AND it.agent.id = :agentId " +
 		"AND (:#{#active == null} = true OR it.active = :active) " +
 		"AND (:#{#keyword == null or #keyword.isEmpty()} = true OR LOWER(it.name) LIKE %:keyword%)")
-	Page<InquiryTemplate> findAllByRealEstateIdAndFilters(@Param("realEstateId") Long realEstateId,
+	Page<InquiryTemplate> findAllByAgentIdAndFilters(@Param("agentId") Long agentId,
 		@Param("active") Boolean active,
 		@Param("keyword") String keyword,
 		Pageable pageable);
 
-	// 🔄 findAllByRealEstateIdAndKeyword
 	@Query("SELECT it FROM InquiryTemplate it " +
 		"WHERE it.deletedAt IS NULL " +
-		"AND it.realEstate.id = :realEstateId " +
+		"AND it.agent.id = :agentId " +
 		"AND (it.name LIKE %:keyword% OR it.description LIKE %:keyword%)")
-	Page<InquiryTemplate> findAllByRealEstateIdAndKeyword(@Param("realEstateId") Long realEstateId,
+	Page<InquiryTemplate> findAllByAgentIdAndKeyword(@Param("agentId") Long agentId,
 		@Param("keyword") String keyword,
 		Pageable pageable);
 
-	// 🔄 existsByRealEstateIdAndName
 	@Query("SELECT CASE WHEN COUNT(it) > 0 THEN true ELSE false END " +
 		"FROM InquiryTemplate it " +
-		"WHERE it.realEstate.id = :realEstateId " +
+		"WHERE it.agent.id = :agentId " +
 		"AND it.name = :name " +
 		"AND it.deletedAt IS NULL")
-	boolean existsByRealEstateIdAndName(@Param("realEstateId") Long realEstateId, @Param("name") String name);
+	boolean existsByAgentIdAndName(@Param("agentId") Long agentId, @Param("name") String name);
 }

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/repository/InquiryTemplateSharedTokenRepository.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/repository/InquiryTemplateSharedTokenRepository.java
@@ -1,0 +1,13 @@
+package com.househub.backend.domain.inquiryTemplate.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplateSharedToken;
+
+@Repository
+public interface InquiryTemplateSharedTokenRepository extends JpaRepository<InquiryTemplateSharedToken, Long> {
+	Optional<InquiryTemplateSharedToken> findByShareTokenAndActiveTrue(String shareToken);
+}

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/service/InquiryTemplateService.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/service/InquiryTemplateService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import com.househub.backend.domain.inquiryTemplate.dto.CreateInquiryTemplateReqDto;
 import com.househub.backend.domain.inquiryTemplate.dto.InquiryTemplateListResDto;
 import com.househub.backend.domain.inquiryTemplate.dto.InquiryTemplatePreviewResDto;
+import com.househub.backend.domain.inquiryTemplate.dto.InquiryTemplateSharedResDto;
 import com.househub.backend.domain.inquiryTemplate.dto.UpdateInquiryTemplateReqDto;
 
 public interface InquiryTemplateService {
@@ -19,4 +20,6 @@ public interface InquiryTemplateService {
 	void updateInquiryTemplate(Long templateId, UpdateInquiryTemplateReqDto reqDto, Long agentId);
 
 	void deleteInquiryTemplate(Long templateId, Long agentId);
+
+	InquiryTemplateSharedResDto getInquiryTemplateByShareToken(String shareToken);
 }

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/service/impl/InquiryTemplateServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/service/impl/InquiryTemplateServiceImpl.java
@@ -55,18 +55,18 @@ public class InquiryTemplateServiceImpl implements InquiryTemplateService {
 	@Transactional
 	public void createNewInquiryTemplate(CreateInquiryTemplateReqDto reqDto, Long agentId) throws
 		AlreadyExistsException {
-		// 1. 중개사 ID로 부동산 존재 여부 확인
-		RealEstate realEstate = getRealEstateByAgentId(agentId);
+		// 1. 중개사 ID로 중개사 존재 여부 확인
+		Agent agent = findAgentById(agentId);
 
 		// 2. 동일한 이름의 문의 템플릿이 이미 존재하는지 확인
-		boolean exists = inquiryTemplateRepository.existsByRealEstateIdAndName(realEstate.getId(),
+		boolean exists = inquiryTemplateRepository.existsByAgentIdAndName(agent.getId(),
 			reqDto.getName());
 		if (exists) {
 			throw new AlreadyExistsException("이미 동일한 이름의 문의 템플릿이 존재합니다.", "DUPLICATED_INQUIRY_TEMPLATE_NAME");
 		}
 
 		// 3. 문의 템플릿 생성
-		InquiryTemplate inquiryTemplate = InquiryTemplate.fromDto(reqDto, realEstate);
+		InquiryTemplate inquiryTemplate = InquiryTemplate.fromDto(reqDto, agent);
 		inquiryTemplateRepository.save(inquiryTemplate);
 
 		// 3. 질문 목록 생성 및 저장
@@ -93,12 +93,11 @@ public class InquiryTemplateServiceImpl implements InquiryTemplateService {
 	@Override
 	public InquiryTemplateListResDto getInquiryTemplates(Boolean active, String keyword, Pageable pageable,
 		Long agentId) {
-		// active 가 null 나 keyword 가 null 인 걸 고려해야 해.
-		// 1. 중개사 ID로 부동산 존재 여부 확인
-		RealEstate realEstate = getRealEstateByAgentId(agentId);
+		// 1. 중개사 ID로 중개사 존재 여부 확인
+		Agent agent = findAgentById(agentId);
 
 		// 2. 문의 템플릿 목록 조회
-		Page<InquiryTemplateResDto> page = inquiryTemplateRepository.findAllByRealEstateIdAndFilters(realEstate.getId(),
+		Page<InquiryTemplateResDto> page = inquiryTemplateRepository.findAllByAgentIdAndFilters(agent.getId(),
 				active,
 				keyword,
 				pageable)
@@ -115,11 +114,11 @@ public class InquiryTemplateServiceImpl implements InquiryTemplateService {
 	 */
 	@Override
 	public InquiryTemplateListResDto searchInquiryTemplates(String keyword, Pageable pageable, Long agentId) {
-		// 1. 중개사 ID로 부동산 존재 여부 확인
-		RealEstate realEstate = getRealEstateByAgentId(agentId);
+		// 1. 중개사 ID로 중개사 존재 여부 확인
+		Agent agent = findAgentById(agentId);
 
 		// 2. 문의 템플릿 목록 검색
-		Page<InquiryTemplateResDto> page = inquiryTemplateRepository.findAllByRealEstateIdAndKeyword(realEstate.getId(),
+		Page<InquiryTemplateResDto> page = inquiryTemplateRepository.findAllByAgentIdAndKeyword(agent.getId(),
 				keyword,
 				pageable)
 			.map(InquiryTemplateResDto::fromEntity);
@@ -134,11 +133,11 @@ public class InquiryTemplateServiceImpl implements InquiryTemplateService {
 	 */
 	@Override
 	public InquiryTemplatePreviewResDto previewInquiryTemplate(Long templateId, Long agentId) {
-		// 1. 중개사 ID로 부동산 존재 여부 확인
-		RealEstate realEstate = getRealEstateByAgentId(agentId);
+		// 1. 중개사 ID로 중개사 존재 여부 확인
+		Agent agent = findAgentById(agentId);
 
 		// 2. 문의 템플릿 ID 와 중개사 ID로 문의 템플릿 조회
-		InquiryTemplate inquiryTemplate = findInquiryTemplateByIdAndRealEstateId(templateId, realEstate.getId());
+		InquiryTemplate inquiryTemplate = findInquiryTemplateByIdAndAgentId(templateId, agent.getId());
 
 		// 3. 문의 템플릿에 속한 질문 목록 조회
 		List<Question> questions = questionRepository.findAllByInquiryTemplate(inquiryTemplate);
@@ -154,11 +153,11 @@ public class InquiryTemplateServiceImpl implements InquiryTemplateService {
 	@Transactional
 	@Override
 	public void updateInquiryTemplate(Long templateId, UpdateInquiryTemplateReqDto reqDto, Long agentId) {
-		// 1. 중개사 ID로 부동산 존재 여부 확인
-		RealEstate realEstate = getRealEstateByAgentId(agentId);
+		// 1. 중개사 ID로 중개사 존재 여부 확인
+		Agent agent = findAgentById(agentId);
 
 		// 2. 문의 템플릿 ID로 문의 템플릿 조회
-		InquiryTemplate inquiryTemplate = findInquiryTemplateByIdAndRealEstateId(templateId, realEstate.getId());
+		InquiryTemplate inquiryTemplate = findInquiryTemplateByIdAndAgentId(templateId, agent.getId());
 
 		// 3. 문의 템플릿 수정
 		if (reqDto.getQuestions() != null) {
@@ -197,11 +196,11 @@ public class InquiryTemplateServiceImpl implements InquiryTemplateService {
 	 */
 	@Override
 	public void deleteInquiryTemplate(Long templateId, Long agentId) {
-		// 1. 중개사 ID로 부동산 존재 여부 확인
-		RealEstate realEstate = getRealEstateByAgentId(agentId);
+		// 1. 중개사 ID로 중개사 존재 여부 확인
+		Agent agent = findAgentById(agentId);
 
 		// 2. 문의 템플릿 ID로 문의 템플릿 조회
-		InquiryTemplate inquiryTemplate = findInquiryTemplateByIdAndRealEstateId(templateId, realEstate.getId());
+		InquiryTemplate inquiryTemplate = findInquiryTemplateByIdAndAgentId(templateId, agent.getId());
 
 		// 3. 문의 템플릿 삭제
 		inquiryTemplateRepository.delete(inquiryTemplate);
@@ -245,14 +244,14 @@ public class InquiryTemplateServiceImpl implements InquiryTemplateService {
 	}
 
 	/**
-	 * 템플릿 ID 및 부동산 객체 로 문의 템플릿을 조회합니다.
+	 * 템플릿 ID 및 중개사 ID 로 문의 템플릿을 조회합니다.
 	 * @param templateId 문의 템플릿 ID
-	 * @param realEstateId 부동산 ID
+	 * @param agentId 중개사 ID
 	 * @return 문의 템플릿 엔티티
 	 * @throws ResourceNotFoundException 해당 문의 템플릿을 찾을 수 없는 경우
 	 */
-	private InquiryTemplate findInquiryTemplateByIdAndRealEstateId(Long templateId, Long realEstateId) {
-		return inquiryTemplateRepository.findByIdAndRealEstateId(templateId, realEstateId)
+	private InquiryTemplate findInquiryTemplateByIdAndAgentId(Long templateId, Long agentId) {
+		return inquiryTemplateRepository.findByIdAndAgentId(templateId, agentId)
 			.orElseThrow(() -> new ResourceNotFoundException("해당 문의 템플릿을 찾을 수 없습니다.", "INQUIRY_TEMPLATE_NOT_FOUND"));
 	}
 


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 문의 템플릿 공유 토큰 엔티티(InquiryTemplateShareToken) 구현
- 문의 템플릿 생성 시 문의 템플릿 공유 토큰 발급 로직 추가
- 문의 템플릿 관계 매핑 대상을 부동산(RealEstate) 에서 중개사(Agent) 로 변경, 그에 따른 로직 변경
- 문의 엔티티(Inquiry) 및 문의 답변 엔티티(InquiryAnswer) 구현
- 고객 후보 엔티티(CustomerCandidate) 구현
- 문의 등록 API 구현

## ✏️ 변경 사항
- 문의 템플릿 공유 토큰 엔티티(InquiryTemplateShareToken) 구현
- 문의 템플릿 생성 시 문의 템플릿 공유 토큰 발급 로직 추가
- 문의 템플릿 관계 매핑 대상을 부동산(RealEstate) 에서 중개사(Agent) 로 변경, 그에 따른 로직 변경
- 문의 엔티티(Inquiry) 및 문의 답변 엔티티(InquiryAnswer) 구현
- 고객 후보 엔티티(CustomerCandidate) 구현
- 문의 등록 API 구현
- 
## 📸 스크린샷

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [x] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈
- #71 
- #72 
