### PR TITLE
seongeun, fix: 페이지네이션 수정 및 계약 enum 변경, 매물 정보 수정 시 고객도 수정 가능하도록 변경

### DIFF
--- a/src/main/java/com/househub/backend/domain/contract/controller/ContractController.java
+++ b/src/main/java/com/househub/backend/domain/contract/controller/ContractController.java
@@ -12,6 +12,7 @@ import com.househub.backend.domain.contract.service.ContractService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -47,7 +48,11 @@ public class ContractController {
 		@ModelAttribute ContractSearchDto searchDto,
 		Pageable pageable
 	) {
-		ContractListResDto response = contractService.findContracts(searchDto, pageable, getSignInAgentId());
+		// page를 1-based에서 0-based로 변경
+		int page = Math.max(pageable.getPageNumber() - 1, 0);
+		int size = pageable.getPageSize();
+		Pageable adjustedPageable = PageRequest.of(page, size, pageable.getSort());
+		ContractListResDto response = contractService.findContracts(searchDto, adjustedPageable, getSignInAgentId());
 		return ResponseEntity.ok(SuccessResponse.success("계약 조회 성공", "FIND_CONTRACTS_SUCCESS", response));
 	}
 

--- a/src/main/java/com/househub/backend/domain/contract/dto/ContractReqDto.java
+++ b/src/main/java/com/househub/backend/domain/contract/dto/ContractReqDto.java
@@ -49,13 +49,13 @@ public class ContractReqDto {
     }
 
     // 자동 실행
-    @AssertTrue(message = "거래 가능 상태일 경우, 거래 시작일과 만료일은 입력할 수 없습니다.")
-    public boolean isValidContractStatus() {
-        if (contractStatus == ContractStatus.AVAILABLE) { // 거래가능일 경우
-            return startedAt == null && expiredAt == null;
-        }
-        return true;
-    }
+    // @AssertTrue(message = "거래 가능 상태일 경우, 거래 시작일과 만료일은 입력할 수 없습니다.")
+    // public boolean isValidContractStatus() {
+    //     if (contractStatus == ContractStatus.AVAILABLE) { // 거래가능일 경우
+    //         return startedAt == null && expiredAt == null;
+    //     }
+    //     return true;
+    // }
 
     public Contract toEntity(Property property, Customer customer, Agent agent) {
         return Contract.builder()

--- a/src/main/java/com/househub/backend/domain/contract/enums/ContractStatus.java
+++ b/src/main/java/com/househub/backend/domain/contract/enums/ContractStatus.java
@@ -1,5 +1,5 @@
 package com.househub.backend.domain.contract.enums;
 
 public enum ContractStatus {
-    AVAILABLE, IN_PROGRESS, COMPLETED
+    IN_PROGRESS, COMPLETED, CANCELED
 }

--- a/src/main/java/com/househub/backend/domain/contract/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/contract/service/impl/ContractServiceImpl.java
@@ -67,11 +67,11 @@ public class ContractServiceImpl implements ContractService {
         // 매물 조회
         Property property = findPropertyById(dto.getPropertyId());
         // 거래 완료 상태 이외의 상태로 변경하는 경우
-        if (dto.getContractStatus() != ContractStatus.COMPLETED) {
-            // 같은 고객과 매물에 대한 완료되지 않은 계약이 있는지 확인
-            // 완료되지 않은 계약이 있으면 예외
-            existsByContractAndProperty(customer, property);
-        }
+        // if (dto.getContractStatus() != ContractStatus.COMPLETED) {
+        //     // 같은 고객과 매물에 대한 완료되지 않은 계약이 있는지 확인
+        //     // 완료되지 않은 계약이 있으면 예외
+        //     existsByContractAndProperty(customer, property);
+        // }
         // 계약 정보 수정
         contract.updateContract(dto);
     }

--- a/src/main/java/com/househub/backend/domain/property/controller/PropertyController.java
+++ b/src/main/java/com/househub/backend/domain/property/controller/PropertyController.java
@@ -8,6 +8,7 @@ import com.househub.backend.domain.property.service.PropertyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -33,7 +34,11 @@ public class PropertyController {
 		@ModelAttribute PropertySearchDto searchDto,
 		Pageable pageable
 	) {
-		PropertyListResDto response = propertyService.findProperties(searchDto, pageable);
+		// page를 1-based에서 0-based로 변경
+		int page = Math.max(pageable.getPageNumber() - 1, 0);
+		int size = pageable.getPageSize();
+		Pageable adjustedPageable = PageRequest.of(page, size, pageable.getSort());
+		PropertyListResDto response = propertyService.findProperties(searchDto, adjustedPageable);
 		return ResponseEntity.ok(SuccessResponse.success("매물 조회 성공", "FIND_PROPERTIES_SUCCESS", response));
 	}
 

--- a/src/main/java/com/househub/backend/domain/property/entity/Property.java
+++ b/src/main/java/com/househub/backend/domain/property/entity/Property.java
@@ -100,7 +100,8 @@ public class Property {
     }
 
     // 수정 메서드 (setter 대신 사용)
-    public void updateProperty(PropertyReqDto updateDto) {
+    public void updateProperty(PropertyReqDto updateDto, Customer customer) {
+        if (updateDto.getCustomerId() != null) this.customer = customer;
         if (updateDto.getPropertyType() != null) this.propertyType = updateDto.getPropertyType();
         if (updateDto.getMemo() != null) this.memo = updateDto.getMemo();
         if (updateDto.getRoadAddress() != null) this.roadAddress = updateDto.getRoadAddress();

--- a/src/main/java/com/househub/backend/domain/property/service/impl/PropertyServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/property/service/impl/PropertyServiceImpl.java
@@ -101,13 +101,13 @@ public class PropertyServiceImpl implements PropertyService {
 	@Override
 	public void updateProperty(Long propertyId, PropertyReqDto updateDto) {
 		// 주소가 동일한 매물이 있는지 확인
-		existsByAddress(updateDto.getRoadAddress(), updateDto.getDetailAddress());
+		// existsByAddress(updateDto.getRoadAddress(), updateDto.getDetailAddress());
 		// 의뢰인(임대인 또는 매도인) 존재 여부 확인
 		Customer customer = findCustomerById(updateDto.getCustomerId());
 		// 매물 조회
 		Property property = findPropertyById(propertyId);
 		// id로 조회한 매물 정보 수정 및 저장
-		property.updateProperty(updateDto);
+		property.updateProperty(updateDto, customer);
 	}
 
 	/**

--- a/src/test/java/com/househub/backend/domain/contract/service/ContractServiceTest.java
+++ b/src/test/java/com/househub/backend/domain/contract/service/ContractServiceTest.java
@@ -102,7 +102,7 @@ public class ContractServiceTest {
 			.customerId(customerId)
 			.contractType(ContractType.JEONSE)
 			.jeonsePrice(10000000L)
-			.contractStatus(ContractStatus.AVAILABLE)
+			.contractStatus(ContractStatus.IN_PROGRESS)
 			.build();
 		when(propertyRepository.findById(requestDto.getPropertyId())).thenReturn(Optional.of(property));
 		when(customerRepository.findById(requestDto.getCustomerId())).thenReturn(Optional.of(customer));
@@ -182,8 +182,8 @@ public class ContractServiceTest {
 		when(contractRepository.findById(anyLong())).thenReturn(Optional.of(contract));
 		when(propertyRepository.findById(anyLong())).thenReturn(Optional.of(property));
 		when(customerRepository.findById(anyLong())).thenReturn(Optional.of(customer));
-		when(requestDto.getContractStatus()).thenReturn(ContractStatus.AVAILABLE);
-		when(contractRepository.existsByCustomerAndPropertyAndStatusNot(any(), any(), any())).thenReturn(false);
+		// when(requestDto.getContractStatus()).thenReturn(ContractStatus.IN_PROGRESS);
+		// when(contractRepository.existsByCustomerAndPropertyAndStatusNot(any(), any(), any())).thenReturn(false);
 
 		// when
 		contractService.updateContract(1L, requestDto);

--- a/src/test/java/com/househub/backend/domain/property/service/PropertyServiceTest.java
+++ b/src/test/java/com/househub/backend/domain/property/service/PropertyServiceTest.java
@@ -154,8 +154,8 @@ public class PropertyServiceTest {
 			.jibunAddress("서울특별시 강남구 삼성동 123-45")
 			.detailAddress("101동 302호")
 			.build();
-		when(propertyRepository.existsByRoadAddressAndDetailAddress(updateDto.getRoadAddress(),
-			updateDto.getDetailAddress())).thenReturn(false);
+		// when(propertyRepository.existsByRoadAddressAndDetailAddress(updateDto.getRoadAddress(),
+		// 	updateDto.getDetailAddress())).thenReturn(false);
 		when(customerRepository.findById(1L)).thenReturn(Optional.of(customer));
 		when(propertyRepository.findById(1L)).thenReturn(Optional.of(property));
 


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 매물, 계약 조회 시 페이지네이션 수정
- 계약 enum (AVAILABLE -> CANCELED) 수정
- 매물 정보 수정 시 고객(의뢰인) 정보도 수정할 수 있도록 변경

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #96 
