### PR TITLE
문의 등록, 문의 목록 조회, 문의 상세정보 조회 API 리팩토링

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,7 +16,7 @@ module.exports = {
                 },
                 'type-enum': ({ type }) => {
                     const realType = type ?? '';
-                    const allowedTypes = ['feat', 'hotfix', 'chore','feature','fix', 'docs'];
+                    const allowedTypes = ['feat', 'hotfix', 'chore','feature','fix', 'docs', 'refactor'];
                     return [allowedTypes.includes(realType), `타입은 ${allowedTypes.join(', ')} 중 하나여야 합니다`];
                 },
                 'subject-empty': ({ subject }) => {

--- a/src/main/java/com/househub/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/househub/backend/common/exception/ErrorCode.java
@@ -15,7 +15,9 @@ public enum ErrorCode {
 		"이메일 발송 중 오류가 발생했습니다. 이메일 주소를 확인하거나 잠시 후 다시 시도해주세요."),
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
 	EMAIL_MISMATCH(HttpStatus.BAD_REQUEST, "EMAIL_MISMATCH", "해당 이메일과 일치하는 중개사가 존재하지 않습니다."),
-	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "비밀번호가 일치하지 않습니다.");
+	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "비밀번호가 일치하지 않습니다."),
+	INVALID_SHARED_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_SHARED_TOKEN", "유효하지 않은 링크입니다."),
+	CONTACT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CONTACT_ALREADY_EXISTS", "이 전화번호로 등록된 고객이 이미 있어요.");
 
 	private final HttpStatus httpStatus;
 	private final String code;   // 프론트에서 오류 코드 구분용 (예: AUTH_CODE_INVALID)

--- a/src/main/java/com/househub/backend/domain/agent/dto/AgentResDto.java
+++ b/src/main/java/com/househub/backend/domain/agent/dto/AgentResDto.java
@@ -1,13 +1,14 @@
 package com.househub.backend.domain.agent.dto;
 
+import java.io.Serializable;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.agent.entity.AgentStatus;
 import com.househub.backend.domain.agent.entity.Role;
+
 import lombok.Builder;
 import lombok.Getter;
-
-import java.io.Serializable;
 
 @Getter
 @Builder
@@ -22,12 +23,23 @@ public class AgentResDto implements Serializable {
 
     public static AgentResDto fromEntity(Agent agent) {
         return AgentResDto.builder()
-                .id(agent.getId())
-                .email(agent.getEmail())
-                .password(agent.getPassword())
-                .name(agent.getName())
-                .role(agent.getRole())
-                .status(agent.getStatus())
-                .build();
+            .id(agent.getId())
+            .email(agent.getEmail())
+            .password(agent.getPassword())
+            .name(agent.getName())
+            .role(agent.getRole())
+            .status(agent.getStatus())
+            .build();
+    }
+
+    public Agent toEntity() {
+        return Agent.builder()
+            .id(this.id)
+            .email(this.email)
+            .password(this.password)
+            .name(this.name)
+            .role(this.role)
+            .status(this.status)
+            .build();
     }
 }

--- a/src/main/java/com/househub/backend/domain/customer/dto/CreateCustomerReqDto.java
+++ b/src/main/java/com/househub/backend/domain/customer/dto/CreateCustomerReqDto.java
@@ -3,6 +3,7 @@ package com.househub.backend.domain.customer.dto;
 import com.househub.backend.common.enums.Gender;
 import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.customer.enums.CustomerStatus;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -18,34 +19,32 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CreateCustomerReqDto {
+	@Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하 여야 합니다.")
+	private String name;
 
-    @NotBlank(message = "이름은 필수입니다.")
-    @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하 여야 합니다.")
-    private String name;
+	private Integer ageGroup;
 
-    private Integer ageGroup;
+	@NotBlank(message = "연락처는 필수입니다.")
+	@Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+	private String contact;
 
-    @NotBlank(message = "연락처는 필수입니다.")
-    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
-    private String contact;
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	private String email;
 
-    @NotBlank(message = "이메일은 필수 입니다.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String email;
+	private String memo;
 
-    private String memo;
+	private Gender gender;
 
-    private Gender gender;
-
-    public Customer toEntity(Agent agent) {
-        return Customer.builder()
-                .name(this.name)
-                .ageGroup(this.ageGroup != null ? this.ageGroup : null)
-                .contact(this.contact)
-                .email(this.email)
-                .memo(this.memo)
-                .gender(this.gender != null ? this.gender : null)
-                .agent(agent)
-                .build();
-    }
+	public Customer toEntity(Agent agent) {
+		return Customer.builder()
+			.name(this.name)
+			.ageGroup(this.ageGroup != null ? this.ageGroup : null)
+			.contact(this.contact)
+			.email(this.email)
+			.memo(this.memo)
+			.gender(this.gender != null ? this.gender : null)
+			.agent(agent)
+			.status(CustomerStatus.POTENTIAL)
+			.build();
+	}
 }

--- a/src/main/java/com/househub/backend/domain/customer/entity/Customer.java
+++ b/src/main/java/com/househub/backend/domain/customer/entity/Customer.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import com.househub.backend.common.enums.Gender;
 import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.enums.CustomerStatus;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -37,7 +38,7 @@ public class Customer {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, length = 50)
+	@Column(nullable = true, length = 50)
 	private String name;
 
 	@Column(nullable = true)
@@ -46,7 +47,7 @@ public class Customer {
 	@Column(nullable = false, unique = true)
 	private String contact;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = true, unique = true)
 	private String email;
 
 	@Column(columnDefinition = "TEXT")
@@ -62,6 +63,8 @@ public class Customer {
 	private LocalDateTime updatedAt;
 
 	private LocalDateTime deletedAt;
+
+	private CustomerStatus status;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "agent_id", nullable = false)

--- a/src/main/java/com/househub/backend/domain/customer/entity/Customer.java
+++ b/src/main/java/com/househub/backend/domain/customer/entity/Customer.java
@@ -64,7 +64,10 @@ public class Customer {
 
 	private LocalDateTime deletedAt;
 
-	private CustomerStatus status;
+	@Builder.Default
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private CustomerStatus status = CustomerStatus.POTENTIAL; // 기본값: 잠재 고객
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "agent_id", nullable = false)
@@ -74,6 +77,7 @@ public class Customer {
 	protected void onCreate() {
 		createdAt = LocalDateTime.now();
 		updatedAt = LocalDateTime.now();
+		status = CustomerStatus.POTENTIAL; // 기본값: 잠재 고객
 	}
 
 	@PreUpdate

--- a/src/main/java/com/househub/backend/domain/customer/enums/CustomerStatus.java
+++ b/src/main/java/com/househub/backend/domain/customer/enums/CustomerStatus.java
@@ -1,0 +1,8 @@
+package com.househub.backend.domain.customer.enums;
+
+public enum CustomerStatus {
+	POTENTIAL,  // 잠재 고객 (문의만 남긴 상태)
+	ACTIVE,     // 상담 중 / 거래 진행 중
+	INACTIVE    // 종료, 철회, 장기 미응답
+}
+

--- a/src/main/java/com/househub/backend/domain/customer/enums/CustomerStatus.java
+++ b/src/main/java/com/househub/backend/domain/customer/enums/CustomerStatus.java
@@ -1,8 +1,18 @@
 package com.househub.backend.domain.customer.enums;
 
 public enum CustomerStatus {
-	POTENTIAL,  // 잠재 고객 (문의만 남긴 상태)
-	ACTIVE,     // 상담 중 / 거래 진행 중
-	INACTIVE    // 종료, 철회, 장기 미응답
+	POTENTIAL("문의 고객"),   // 아직 상담은 진행되지 않은 잠재 고객
+	ACTIVE("진행 중"),       // 현재 상담 또는 거래 진행 중인 고객
+	INACTIVE("종료됨");      // 거래 종료, 철회, 또는 장기 미응답 고객
+
+	private String name;
+
+	CustomerStatus(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
 }
 

--- a/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepository.java
@@ -18,7 +18,7 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
 	Optional<Customer> findByEmail(String email);
 
-	Optional<Customer> findByContact(String contact);
+	Optional<Customer> findByContactAndAgentId(String contact, Long agentId);
 
 	Optional<Customer> findByIdAndAgentAndDeletedAtIsNull(Long id, Agent agent);
 

--- a/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepository.java
@@ -18,6 +18,8 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
 	Optional<Customer> findByEmail(String email);
 
+	Optional<Customer> findByContact(String contact);
+
 	Optional<Customer> findByIdAndAgentAndDeletedAtIsNull(Long id, Agent agent);
 
 	Optional<Customer> findByEmailAndContact(String email, String phone);

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerExecutor.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerExecutor.java
@@ -5,5 +5,5 @@ import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
 import com.househub.backend.domain.customer.entity.Customer;
 
 public interface CustomerExecutor {
-	Customer saveCustomerIfNotExists(CreateCustomerReqDto request, Agent agent);
+	Customer findOrCreateCustomer(CreateCustomerReqDto request, Agent agent);
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerExecutor.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerExecutor.java
@@ -1,0 +1,9 @@
+package com.househub.backend.domain.customer.service;
+
+import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.entity.Customer;
+
+public interface CustomerExecutor {
+	Customer saveCustomerIfNotExists(CreateCustomerReqDto request, Agent agent);
+}

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerReader.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerReader.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 import com.househub.backend.domain.customer.entity.Customer;
 
 public interface CustomerReader {
-	Optional<Customer> findCustomerByContact(String contact);
+	Optional<Customer> findByContact(String contact);
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerReader.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerReader.java
@@ -1,0 +1,9 @@
+package com.househub.backend.domain.customer.service;
+
+import java.util.Optional;
+
+import com.househub.backend.domain.customer.entity.Customer;
+
+public interface CustomerReader {
+	Optional<Customer> findCustomerByContact(String contact);
+}

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerReader.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerReader.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 import com.househub.backend.domain.customer.entity.Customer;
 
 public interface CustomerReader {
-	Optional<Customer> findByContact(String contact);
+	Optional<Customer> findByContactAndAgentId(String contact, Long agentId);
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerService.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerService.java
@@ -11,16 +11,15 @@ import com.househub.backend.domain.customer.dto.CustomerListResDto;
 
 public interface CustomerService {
 
+	CreateCustomerResDto createCustomer(CreateCustomerReqDto request, Long agentId);
 
-    CreateCustomerResDto createCustomer(CreateCustomerReqDto request, Long agentId);
+	CreateCustomerResDto findByIdAndDeletedAtIsNull(Long id, Long agentId);
 
-    CreateCustomerResDto findByIdAndDeletedAtIsNull(Long id, Long agentId);
+	CreateCustomerResDto updateCustomer(Long id, CreateCustomerReqDto reqDto, Long agentId);
 
-    CreateCustomerResDto updateCustomer(Long id, CreateCustomerReqDto reqDto, Long agentId);
+	CreateCustomerResDto deleteCustomer(Long id, Long agentId);
 
-    CreateCustomerResDto deleteCustomer(Long id, Long agentId);
+	CustomerListResDto findAllByDeletedAtIsNull(String searchDto, Long agentId, Pageable pageable);
 
-    CustomerListResDto findAllByDeletedAtIsNull(String searchDto, Long agentId, Pageable pageable);
-
-    List<CreateCustomerResDto> createCustomersByExcel(MultipartFile file, Long agentId);
+	List<CreateCustomerResDto> createCustomersByExcel(MultipartFile file, Long agentId);
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerStore.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerStore.java
@@ -1,0 +1,7 @@
+package com.househub.backend.domain.customer.service;
+
+import com.househub.backend.domain.customer.entity.Customer;
+
+public interface CustomerStore {
+	Customer save(Customer customer);
+}

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerStore.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerStore.java
@@ -3,5 +3,5 @@ package com.househub.backend.domain.customer.service;
 import com.househub.backend.domain.customer.entity.Customer;
 
 public interface CustomerStore {
-	Customer save(Customer customer);
+	Customer create(Customer customer);
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerExecutorImpl.java
@@ -1,0 +1,30 @@
+package com.househub.backend.domain.customer.service.impl;
+
+import org.springframework.stereotype.Component;
+
+import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.customer.service.CustomerExecutor;
+import com.househub.backend.domain.customer.service.CustomerReader;
+import com.househub.backend.domain.customer.service.CustomerStore;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomerExecutorImpl implements CustomerExecutor {
+	private final CustomerReader customerReader;
+	private final CustomerStore customerStore;
+
+	@Transactional
+	@Override
+	public Customer saveCustomerIfNotExists(CreateCustomerReqDto request, Agent agent) {
+		// 전화번호로 고객 조회해서 존재하지 않으면 고객 생성
+		return customerReader.findCustomerByContact(request.getContact())
+			.orElseGet(() -> customerStore.save(
+				request.toEntity(agent)
+			));
+	}
+}

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerExecutorImpl.java
@@ -20,10 +20,10 @@ public class CustomerExecutorImpl implements CustomerExecutor {
 
 	@Transactional
 	@Override
-	public Customer saveCustomerIfNotExists(CreateCustomerReqDto request, Agent agent) {
+	public Customer findOrCreateCustomer(CreateCustomerReqDto request, Agent agent) {
 		// 전화번호로 고객 조회해서 존재하지 않으면 고객 생성
-		return customerReader.findCustomerByContact(request.getContact())
-			.orElseGet(() -> customerStore.save(
+		return customerReader.findByContact(request.getContact())
+			.orElseGet(() -> customerStore.create(
 				request.toEntity(agent)
 			));
 	}

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerExecutorImpl.java
@@ -22,7 +22,7 @@ public class CustomerExecutorImpl implements CustomerExecutor {
 	@Override
 	public Customer findOrCreateCustomer(CreateCustomerReqDto request, Agent agent) {
 		// 전화번호로 고객 조회해서 존재하지 않으면 고객 생성
-		return customerReader.findByContact(request.getContact())
+		return customerReader.findByContactAndAgentId(request.getContact(), agent.getId())
 			.orElseGet(() -> customerStore.create(
 				request.toEntity(agent)
 			));

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerReaderImpl.java
@@ -16,7 +16,7 @@ public class CustomerReaderImpl implements CustomerReader {
 	private final CustomerRepository customerRepository;
 
 	@Override
-	public Optional<Customer> findCustomerByContact(String contact) {
+	public Optional<Customer> findByContact(String contact) {
 		return customerRepository.findByContact(contact);
 	}
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerReaderImpl.java
@@ -15,8 +15,9 @@ import lombok.RequiredArgsConstructor;
 public class CustomerReaderImpl implements CustomerReader {
 	private final CustomerRepository customerRepository;
 
+	// 고객을 연락처와 agentId 로 조회
 	@Override
-	public Optional<Customer> findByContact(String contact) {
-		return customerRepository.findByContact(contact);
+	public Optional<Customer> findByContactAndAgentId(String contact, Long agentId) {
+		return customerRepository.findByContactAndAgentId(contact, agentId);
 	}
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerReaderImpl.java
@@ -1,0 +1,22 @@
+package com.househub.backend.domain.customer.service.impl;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.customer.repository.CustomerRepository;
+import com.househub.backend.domain.customer.service.CustomerReader;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerReaderImpl implements CustomerReader {
+	private final CustomerRepository customerRepository;
+
+	@Override
+	public Optional<Customer> findCustomerByContact(String contact) {
+		return customerRepository.findByContact(contact);
+	}
+}

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerStoreImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerStoreImpl.java
@@ -1,0 +1,22 @@
+package com.househub.backend.domain.customer.service.impl;
+
+import org.springframework.stereotype.Component;
+
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.customer.repository.CustomerRepository;
+import com.househub.backend.domain.customer.service.CustomerStore;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomerStoreImpl implements CustomerStore {
+	private final CustomerRepository customerRepository;
+
+	@Transactional
+	@Override
+	public Customer save(Customer customer) {
+		return customerRepository.save(customer);
+	}
+}

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerStoreImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerStoreImpl.java
@@ -16,7 +16,7 @@ public class CustomerStoreImpl implements CustomerStore {
 
 	@Transactional
 	@Override
-	public Customer save(Customer customer) {
+	public Customer create(Customer customer) {
 		return customerRepository.save(customer);
 	}
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryCommand.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryCommand.java
@@ -1,0 +1,17 @@
+package com.househub.backend.domain.inquiry.dto;
+
+import java.util.List;
+
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+
+import lombok.Builder;
+
+@Builder
+public record CreateInquiryCommand(
+	InquiryTemplate template,
+	Customer customer,
+	List<CreateInquiryReqDto.AnswerDto> answers
+) {
+}
+

--- a/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryReqDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryReqDto.java
@@ -2,6 +2,8 @@ package com.househub.backend.domain.inquiry.dto;
 
 import java.util.List;
 
+import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -39,5 +41,14 @@ public class CreateInquiryReqDto {
 		private Long questionId;
 		private Object answerText; // String, List<String> 모두 가능
 	}
+
+	public CreateCustomerReqDto toCustomerReqDto() {
+		return CreateCustomerReqDto.builder()
+			.name(this.name)
+			.email(this.email)
+			.contact(this.phone)
+			.build();
+	}
+
 }
 

--- a/src/main/java/com/househub/backend/domain/inquiry/dto/InquiryDetailResDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/dto/InquiryDetailResDto.java
@@ -3,6 +3,7 @@ package com.househub.backend.domain.inquiry.dto;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.househub.backend.domain.customer.entity.Customer;
 import com.househub.backend.domain.inquiry.entity.Inquiry;
 
 import lombok.AllArgsConstructor;
@@ -34,12 +35,10 @@ public class InquiryDetailResDto {
 	}
 
 	public static InquiryDetailResDto fromEntity(Inquiry inquiry) {
-		String name =
-			inquiry.getCustomer() != null ? inquiry.getCustomer().getName() : inquiry.getCandidate().getName();
-		String email =
-			inquiry.getCustomer() != null ? inquiry.getCustomer().getEmail() : inquiry.getCandidate().getEmail();
-		String contact =
-			inquiry.getCustomer() != null ? inquiry.getCustomer().getContact() : inquiry.getCandidate().getContact();
+		Customer customer = inquiry.getCustomer();
+		String name = customer.getName() != null ? customer.getName() : "미입력";
+		String email = customer.getEmail() != null ? customer.getEmail() : "미입력";
+		String contact = customer.getContact() != null ? customer.getContact() : "미입력";
 
 		List<AnswerDto> answers = inquiry.getAnswers().stream()
 			.map(a -> AnswerDto.builder()

--- a/src/main/java/com/househub/backend/domain/inquiry/dto/InquiryListItemResDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/dto/InquiryListItemResDto.java
@@ -1,24 +1,39 @@
 package com.househub.backend.domain.inquiry.dto;
 
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.inquiry.entity.Inquiry;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class InquiryListItemResDto {
 	private Long inquiryId;
-	private CustomerType customerType;
 	private String name;
 	private String email;
 	private String contact;
 	private String createdAt;
+	private String customerStatus;
 
-	public enum CustomerType {
-		CUSTOMER,
-		CUSTOMER_CANDIDATE
+	public static InquiryListItemResDto from(Inquiry inquiry) {
+		Customer customer = inquiry.getCustomer();
+		return builder()
+			.inquiryId(inquiry.getId())
+			.name(Optional.ofNullable(customer.getName()).orElse("미입력"))
+			.email(Optional.ofNullable(customer.getEmail()).orElse("미입력"))
+			.contact(Optional.ofNullable(customer.getContact()).orElse("미입력"))
+			.createdAt(inquiry.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+			.customerStatus(customer.getStatus().getName())
+			.build();
 	}
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/entity/Inquiry.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.househub.backend.domain.customer.entity.Customer;
-import com.househub.backend.domain.customer.entity.CustomerCandidate;
 import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
 
 import jakarta.persistence.CascadeType;
@@ -45,11 +44,6 @@ public class Inquiry {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "customer_id")
 	private Customer customer; // null 허용
-
-	// 아직 고객 등록되지 않은 임시 문의자
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "customer_candidate_id")
-	private CustomerCandidate candidate; // null 허용
 
 	// 문의 항목에 대한 실제 답변 리스트
 	@OneToMany(mappedBy = "inquiry", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/househub/backend/domain/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/repository/InquiryRepository.java
@@ -18,31 +18,25 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 			SELECT i
 			FROM Inquiry i
 			LEFT JOIN FETCH i.customer c
-			LEFT JOIN FETCH i.candidate cc
 			WHERE
-				(c.agent.id = :agentId OR (c IS NULL AND cc IS NOT NULL))
+				(c.agent.id = :agentId)
 				AND (
 					:keyword IS NULL OR
 					LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
 					LOWER(c.contact) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-					LOWER(c.email) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-					LOWER(cc.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-					LOWER(cc.contact) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-					LOWER(cc.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+					LOWER(c.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
 				)
 		""")
-	Page<Inquiry> findInquiriesWithCustomerOrCandidate(
+	Page<Inquiry> findInquiriesWithCustomer(
 		@Param("agentId") Long agentId,
 		@Param("keyword") String keyword,
 		Pageable pageable
 	);
-	
+
 	@Query("SELECT i FROM Inquiry i " +
 		"LEFT JOIN FETCH i.customer c " +
-		"LEFT JOIN FETCH i.candidate cc " +
 		"LEFT JOIN FETCH i.answers a " +
 		"LEFT JOIN FETCH a.question q " +
 		"WHERE i.id = :inquiryId")
 	Optional<Inquiry> findWithDetailsById(@Param("inquiryId") Long inquiryId);
-
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/service/InquiryExecutor.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/InquiryExecutor.java
@@ -1,13 +1,8 @@
 package com.househub.backend.domain.inquiry.service;
 
-import java.util.List;
-
-import com.househub.backend.domain.customer.entity.Customer;
-import com.househub.backend.domain.inquiry.dto.CreateInquiryReqDto;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryCommand;
 import com.househub.backend.domain.inquiry.entity.Inquiry;
-import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
 
 public interface InquiryExecutor {
-	Inquiry executeInquiryCreation(List<CreateInquiryReqDto.AnswerDto> answers, InquiryTemplate template,
-		Customer customer);
+	Inquiry executeInquiryCreation(CreateInquiryCommand command);
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/service/InquiryExecutor.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/InquiryExecutor.java
@@ -1,0 +1,13 @@
+package com.househub.backend.domain.inquiry.service;
+
+import java.util.List;
+
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryReqDto;
+import com.househub.backend.domain.inquiry.entity.Inquiry;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+
+public interface InquiryExecutor {
+	Inquiry executeInquiryCreation(List<CreateInquiryReqDto.AnswerDto> answers, InquiryTemplate template,
+		Customer customer);
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/service/InquiryReader.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/InquiryReader.java
@@ -2,9 +2,17 @@ package com.househub.backend.domain.inquiry.service;
 
 import java.util.Map;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.househub.backend.domain.inquiry.entity.Inquiry;
 import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
 import com.househub.backend.domain.inquiryTemplate.entity.Question;
 
 public interface InquiryReader {
 	Map<Long, Question> getQuestionMap(InquiryTemplate inquiryTemplate);
+
+	Page<Inquiry> findPageByAgentIdAndKeyword(Long agentId, String keyword, Pageable pageable);
+
+	Inquiry findInquiryWithDetailsOrThrow(Long inquiryId);
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/service/InquiryReader.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/InquiryReader.java
@@ -1,0 +1,10 @@
+package com.househub.backend.domain.inquiry.service;
+
+import java.util.Map;
+
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+import com.househub.backend.domain.inquiryTemplate.entity.Question;
+
+public interface InquiryReader {
+	Map<Long, Question> getQuestionMap(InquiryTemplate inquiryTemplate);
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/service/InquiryStore.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/InquiryStore.java
@@ -4,7 +4,7 @@ import com.househub.backend.domain.inquiry.entity.Inquiry;
 import com.househub.backend.domain.inquiry.entity.InquiryAnswer;
 
 public interface InquiryStore {
-	Inquiry save(Inquiry inquiry);
+	Inquiry create(Inquiry inquiry);
 
-	void saveAnswer(InquiryAnswer inquiryAnswer);
+	void createAnswer(InquiryAnswer inquiryAnswer);
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/service/InquiryStore.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/InquiryStore.java
@@ -1,0 +1,10 @@
+package com.househub.backend.domain.inquiry.service;
+
+import com.househub.backend.domain.inquiry.entity.Inquiry;
+import com.househub.backend.domain.inquiry.entity.InquiryAnswer;
+
+public interface InquiryStore {
+	Inquiry save(Inquiry inquiry);
+
+	void saveAnswer(InquiryAnswer inquiryAnswer);
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryExecutorImpl.java
@@ -28,7 +28,7 @@ public class InquiryExecutorImpl implements InquiryExecutor {
 	// 문의 및 문의 답변 생성
 	public Inquiry executeInquiryCreation(CreateInquiryCommand command) {
 		// 문의 저장
-		Inquiry inquiry = inquiryStore.save(Inquiry.builder()
+		Inquiry inquiry = inquiryStore.create(Inquiry.builder()
 			.template(command.template())
 			.customer(command.customer())
 			.build());
@@ -48,7 +48,7 @@ public class InquiryExecutorImpl implements InquiryExecutor {
 				.answer(serializedAnswer)
 				.build();
 
-			inquiryStore.saveAnswer(answer);
+			inquiryStore.createAnswer(answer);
 		}
 
 		return inquiry;

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryExecutorImpl.java
@@ -1,0 +1,69 @@
+package com.househub.backend.domain.inquiry.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryReqDto;
+import com.househub.backend.domain.inquiry.entity.Inquiry;
+import com.househub.backend.domain.inquiry.entity.InquiryAnswer;
+import com.househub.backend.domain.inquiry.exception.InvalidAnswerFormatException;
+import com.househub.backend.domain.inquiry.service.InquiryExecutor;
+import com.househub.backend.domain.inquiry.service.InquiryReader;
+import com.househub.backend.domain.inquiry.service.InquiryStore;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+import com.househub.backend.domain.inquiryTemplate.entity.Question;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class InquiryExecutorImpl implements InquiryExecutor {
+	private final InquiryReader inquiryReader;
+	private final InquiryStore inquiryStore;
+	private final ObjectMapper objectMapper;
+
+	public Inquiry executeInquiryCreation(List<CreateInquiryReqDto.AnswerDto> answers, InquiryTemplate template,
+		Customer customer) {
+		// 문의 저장
+		Inquiry inquiry = inquiryStore.save(Inquiry.builder()
+			.template(template)
+			.customer(customer)
+			.build());
+
+		// 질문 목록 캐싱
+		Map<Long, Question> questionMap = inquiryReader.getQuestionMap(template);
+
+		// 답변 저장
+		for (CreateInquiryReqDto.AnswerDto answerDto : answers) {
+			Question question = questionMap.get(answerDto.getQuestionId());
+
+			String serializedAnswer = serializeAnswer(answerDto.getAnswerText());
+
+			InquiryAnswer answer = InquiryAnswer.builder()
+				.inquiry(inquiry)
+				.question(question)
+				.answer(serializedAnswer)
+				.build();
+
+			inquiryStore.saveAnswer(answer);
+		}
+
+		return inquiry;
+	}
+
+	private String serializeAnswer(Object answerText) {
+		try {
+			if (answerText instanceof String) {
+				return (String)answerText;
+			}
+			return objectMapper.writeValueAsString(answerText);
+		} catch (JsonProcessingException e) {
+			throw new InvalidAnswerFormatException();
+		}
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryExecutorImpl.java
@@ -1,13 +1,12 @@
 package com.househub.backend.domain.inquiry.service.impl;
 
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.househub.backend.domain.customer.entity.Customer;
+import com.househub.backend.domain.inquiry.dto.CreateInquiryCommand;
 import com.househub.backend.domain.inquiry.dto.CreateInquiryReqDto;
 import com.househub.backend.domain.inquiry.entity.Inquiry;
 import com.househub.backend.domain.inquiry.entity.InquiryAnswer;
@@ -15,7 +14,6 @@ import com.househub.backend.domain.inquiry.exception.InvalidAnswerFormatExceptio
 import com.househub.backend.domain.inquiry.service.InquiryExecutor;
 import com.househub.backend.domain.inquiry.service.InquiryReader;
 import com.househub.backend.domain.inquiry.service.InquiryStore;
-import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
 import com.househub.backend.domain.inquiryTemplate.entity.Question;
 
 import lombok.RequiredArgsConstructor;
@@ -27,19 +25,19 @@ public class InquiryExecutorImpl implements InquiryExecutor {
 	private final InquiryStore inquiryStore;
 	private final ObjectMapper objectMapper;
 
-	public Inquiry executeInquiryCreation(List<CreateInquiryReqDto.AnswerDto> answers, InquiryTemplate template,
-		Customer customer) {
+	// 문의 및 문의 답변 생성
+	public Inquiry executeInquiryCreation(CreateInquiryCommand command) {
 		// 문의 저장
 		Inquiry inquiry = inquiryStore.save(Inquiry.builder()
-			.template(template)
-			.customer(customer)
+			.template(command.template())
+			.customer(command.customer())
 			.build());
 
 		// 질문 목록 캐싱
-		Map<Long, Question> questionMap = inquiryReader.getQuestionMap(template);
+		Map<Long, Question> questionMap = inquiryReader.getQuestionMap(command.template());
 
 		// 답변 저장
-		for (CreateInquiryReqDto.AnswerDto answerDto : answers) {
+		for (CreateInquiryReqDto.AnswerDto answerDto : command.answers()) {
 			Question question = questionMap.get(answerDto.getQuestionId());
 
 			String serializedAnswer = serializeAnswer(answerDto.getAnswerText());

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryReaderImpl.java
@@ -1,0 +1,20 @@
+package com.househub.backend.domain.inquiry.service.impl;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.househub.backend.domain.inquiry.service.InquiryReader;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+import com.househub.backend.domain.inquiryTemplate.entity.Question;
+
+@Component
+public class InquiryReaderImpl implements InquiryReader {
+	@Override
+	public Map<Long, Question> getQuestionMap(InquiryTemplate inquiryTemplate) {
+		return inquiryTemplate.getQuestions().stream()
+			.collect(Collectors.toMap(Question::getId, Function.identity()));
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryReaderImpl.java
@@ -4,17 +4,43 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import com.househub.backend.common.exception.BusinessException;
+import com.househub.backend.common.exception.ErrorCode;
+import com.househub.backend.domain.inquiry.entity.Inquiry;
+import com.househub.backend.domain.inquiry.repository.InquiryRepository;
 import com.househub.backend.domain.inquiry.service.InquiryReader;
 import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
 import com.househub.backend.domain.inquiryTemplate.entity.Question;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class InquiryReaderImpl implements InquiryReader {
+	private final InquiryRepository inquiryRepository;
+
 	@Override
 	public Map<Long, Question> getQuestionMap(InquiryTemplate inquiryTemplate) {
 		return inquiryTemplate.getQuestions().stream()
 			.collect(Collectors.toMap(Question::getId, Function.identity()));
+	}
+
+	@Override
+	public Page<Inquiry> findPageByAgentIdAndKeyword(Long agentId, String keyword, Pageable pageable) {
+		return inquiryRepository.findInquiriesWithCustomer(
+			agentId,
+			keyword,
+			pageable
+		);
+	}
+
+	@Override
+	public Inquiry findInquiryWithDetailsOrThrow(Long inquiryId) {
+		return inquiryRepository.findWithDetailsById(inquiryId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryServiceImpl.java
@@ -1,18 +1,10 @@
 package com.househub.backend.domain.inquiry.service.impl;
 
-import java.time.format.DateTimeFormatter;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.househub.backend.common.exception.BusinessException;
-import com.househub.backend.common.exception.ErrorCode;
-import com.househub.backend.common.exception.ResourceNotFoundException;
-import com.househub.backend.domain.agent.entity.Agent;
-import com.househub.backend.domain.agent.entity.AgentStatus;
-import com.househub.backend.domain.agent.repository.AgentRepository;
 import com.househub.backend.domain.customer.entity.Customer;
 import com.househub.backend.domain.customer.service.CustomerExecutor;
 import com.househub.backend.domain.inquiry.dto.CreateInquiryCommand;
@@ -22,22 +14,23 @@ import com.househub.backend.domain.inquiry.dto.InquiryDetailResDto;
 import com.househub.backend.domain.inquiry.dto.InquiryListItemResDto;
 import com.househub.backend.domain.inquiry.dto.InquiryListResDto;
 import com.househub.backend.domain.inquiry.entity.Inquiry;
-import com.househub.backend.domain.inquiry.repository.InquiryRepository;
 import com.househub.backend.domain.inquiry.service.InquiryExecutor;
+import com.househub.backend.domain.inquiry.service.InquiryReader;
 import com.househub.backend.domain.inquiry.service.InquiryService;
 import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
 import com.househub.backend.domain.inquiryTemplate.service.InquiryTemplateReader;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InquiryServiceImpl implements InquiryService {
 	private final CustomerExecutor customerExecutor;
 	private final InquiryTemplateReader inquiryTemplateReader;
 	private final InquiryExecutor inquiryExecutor;
-	private final InquiryRepository inquiryRepository;
-	private final AgentRepository agentRepository;
+	private final InquiryReader inquiryReader;
 
 	/**
 	 * 문의를 생성합니다.
@@ -82,48 +75,18 @@ public class InquiryServiceImpl implements InquiryService {
 	 */
 	@Override
 	public InquiryListResDto getInquiries(Long agentId, String keyword, Pageable pageable) {
-		// 1. 중개사 ID로 중개사 존재 여부 확인
-		findAgentById(agentId);
+		// 1. 문의 목록 검색
+		Page<Inquiry> inquiries = inquiryReader.findPageByAgentIdAndKeyword(agentId, keyword, pageable);
 
-		// 2. 문의 목록 검색
-		Page<Inquiry> inquiries = inquiryRepository.findInquiriesWithCustomerOrCandidate(agentId, keyword, pageable);
-
-		// 3. 문의 목록을 InquiryListResDto로 변환
-		Page<InquiryListItemResDto> dtoPage = inquiries.map(i -> {
-			boolean hasCustomer = i.getCustomer() != null;
-
-			return InquiryListItemResDto.builder()
-				.inquiryId(i.getId())
-				.customerType(hasCustomer ?
-					InquiryListItemResDto.CustomerType.CUSTOMER :
-					InquiryListItemResDto.CustomerType.CUSTOMER_CANDIDATE)
-				.name(hasCustomer ? i.getCustomer().getName() : i.getCandidate().getName())
-				.email(hasCustomer ? i.getCustomer().getEmail() : i.getCandidate().getEmail())
-				.contact(hasCustomer ? i.getCustomer().getContact() : i.getCandidate().getContact())
-				.createdAt(i.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
-				.build();
-		});
+		// 2. 문의 목록을 InquiryListResDto로 변환
+		Page<InquiryListItemResDto> dtoPage = inquiries.map(InquiryListItemResDto::from);
 
 		return InquiryListResDto.fromPage(dtoPage);
 	}
 
 	@Override
 	public InquiryDetailResDto getInquiryDetail(Long inquiryId) {
-		Inquiry inquiry = inquiryRepository.findWithDetailsById(inquiryId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
-
+		Inquiry inquiry = inquiryReader.findInquiryWithDetailsOrThrow(inquiryId);
 		return InquiryDetailResDto.fromEntity(inquiry);
-	}
-
-	/**
-	 *
-	 * @param agentId 중개사 ID
-	 * @return 중개사 엔티티
-	 * @throws ResourceNotFoundException 해당 중개사를 찾을 수 없는 경우
-	 */
-	private Agent findAgentById(Long agentId) {
-		// agentId 로 중개사 조회하는데, status 가 반드시 ACTIVE 인 중개사만 조회
-		return agentRepository.findByIdAndStatus(agentId, AgentStatus.ACTIVE)
-			.orElseThrow(() -> new ResourceNotFoundException("해당 중개사를 찾을 수 없습니다.", "AGENT_NOT_FOUND"));
 	}
 }

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryServiceImpl.java
@@ -1,18 +1,12 @@
 package com.househub.backend.domain.inquiry.service.impl;
 
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.househub.backend.common.exception.BusinessException;
 import com.househub.backend.common.exception.ErrorCode;
 import com.househub.backend.common.exception.ResourceNotFoundException;
@@ -20,40 +14,28 @@ import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.agent.entity.AgentStatus;
 import com.househub.backend.domain.agent.repository.AgentRepository;
 import com.househub.backend.domain.customer.entity.Customer;
-import com.househub.backend.domain.customer.entity.CustomerCandidate;
-import com.househub.backend.domain.customer.repository.CustomerCandidateRepository;
-import com.househub.backend.domain.customer.repository.CustomerRepository;
+import com.househub.backend.domain.customer.service.CustomerExecutor;
 import com.househub.backend.domain.inquiry.dto.CreateInquiryReqDto;
 import com.househub.backend.domain.inquiry.dto.CreateInquiryResDto;
 import com.househub.backend.domain.inquiry.dto.InquiryDetailResDto;
 import com.househub.backend.domain.inquiry.dto.InquiryListItemResDto;
 import com.househub.backend.domain.inquiry.dto.InquiryListResDto;
 import com.househub.backend.domain.inquiry.entity.Inquiry;
-import com.househub.backend.domain.inquiry.entity.InquiryAnswer;
-import com.househub.backend.domain.inquiry.exception.InvalidAnswerFormatException;
-import com.househub.backend.domain.inquiry.exception.QuestionNotFoundException;
-import com.househub.backend.domain.inquiry.repository.InquiryAnswerRepository;
 import com.househub.backend.domain.inquiry.repository.InquiryRepository;
+import com.househub.backend.domain.inquiry.service.InquiryExecutor;
 import com.househub.backend.domain.inquiry.service.InquiryService;
 import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
-import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplateSharedToken;
-import com.househub.backend.domain.inquiryTemplate.entity.Question;
-import com.househub.backend.domain.inquiryTemplate.repository.InquiryTemplateRepository;
-import com.househub.backend.domain.inquiryTemplate.repository.InquiryTemplateSharedTokenRepository;
+import com.househub.backend.domain.inquiryTemplate.service.InquiryTemplateReader;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class InquiryServiceImpl implements InquiryService {
-	private final InquiryTemplateRepository templateRepository;
-	private final InquiryTemplateSharedTokenRepository sharedTokenRepository;
+	private final CustomerExecutor customerExecutor;
+	private final InquiryTemplateReader inquiryTemplateReader;
+	private final InquiryExecutor inquiryExecutor;
 	private final InquiryRepository inquiryRepository;
-	private final InquiryAnswerRepository inquiryAnswerRepository;
-	private final CustomerRepository customerRepository;
-	private final CustomerCandidateRepository customerCandidateRepository;
-	private final ObjectMapper objectMapper;
-
 	private final AgentRepository agentRepository;
 
 	/**
@@ -66,73 +48,19 @@ public class InquiryServiceImpl implements InquiryService {
 	@Override
 	public CreateInquiryResDto createInquiry(CreateInquiryReqDto reqDto) {
 		// templateToken 으로 InquiryTemplateShareToken 엔티티 조회
-		InquiryTemplateSharedToken shareToken = sharedTokenRepository.findByShareTokenAndActiveTrue(
-				reqDto.getTemplateToken())
-			.orElseThrow(() -> new ResourceNotFoundException("유효하지 않은 문의 템플릿 링크입니다.", "TEMPLATE_NOT_FOUND"));
-
-		InquiryTemplate template = shareToken.getTemplate();
-
-		if (template.getQuestions().isEmpty()) {
-			throw new ResourceNotFoundException("문의 템플릿에 질문이 존재하지 않습니다.", "TEMPLATE_QUESTION_NOT_FOUND");
-		}
+		InquiryTemplate template = inquiryTemplateReader.getValidTemplate(reqDto.getTemplateToken());
 
 		// 문의 남긴 고객이 DB 에 존재하는지 확인
-		Optional<Customer> optCustomer = customerRepository.findByEmailAndContact(reqDto.getEmail(), reqDto.getPhone());
-
-		// 고객이 DB에 존재하지 않는 경우, 고객 후보로 저장
-		// 고객 후보는 고객과 1:1 관계이므로, 고객이 존재하지 않는 경우에만 저장
-		CustomerCandidate candidate = null;
-		if (optCustomer.isEmpty()) {
-			candidate = customerCandidateRepository
-				.findByEmailAndContact(reqDto.getEmail(), reqDto.getPhone())
-				.orElseGet(() -> customerCandidateRepository.save(
-					CustomerCandidate.builder()
-						.name(reqDto.getName())
-						.email(reqDto.getEmail())
-						.contact(reqDto.getPhone())
-						.build()
-				));
-		}
-
-		// 문의 생성
-		Inquiry inquiry = inquiryRepository.save(
-			Inquiry.builder()
-				.template(template)
-				.customer(optCustomer.orElse(null))
-				.candidate(candidate)
-				.build()
+		// 고객이 DB에 존재하지 않는 경우, 고객 새로 생성
+		Customer customer = customerExecutor.saveCustomerIfNotExists(
+			reqDto.toCustomerReqDto(),
+			template.getAgent()
 		);
 
-		// 질문 목록 캐싱
-		Map<Long, Question> questionMap = template.getQuestions().stream()
-			.collect(Collectors.toMap(Question::getId, Function.identity()));
-
-		// 답변 저장
-		for (CreateInquiryReqDto.AnswerDto answerDto : reqDto.getAnswers()) {
-			Question question = questionMap.get(answerDto.getQuestionId());
-
-			if (question == null)
-				throw new QuestionNotFoundException(answerDto.getQuestionId());
-
-			String serializedAnswer;
-			try {
-				if (answerDto.getAnswerText() instanceof String) {
-					serializedAnswer = (String)answerDto.getAnswerText();
-				} else {
-					serializedAnswer = objectMapper.writeValueAsString(answerDto.getAnswerText());
-				}
-			} catch (JsonProcessingException e) {
-				throw new InvalidAnswerFormatException();
-			}
-
-			InquiryAnswer answer = InquiryAnswer.builder()
-				.inquiry(inquiry)
-				.question(question)
-				.answer(serializedAnswer)
-				.build();
-
-			inquiryAnswerRepository.save(answer);
-		}
+		Inquiry inquiry = inquiryExecutor.executeInquiryCreation(
+			reqDto.getAnswers(),
+			template,
+			customer);
 
 		return CreateInquiryResDto.builder()
 			.inquiryId(inquiry.getId())

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryStoreImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryStoreImpl.java
@@ -1,0 +1,28 @@
+package com.househub.backend.domain.inquiry.service.impl;
+
+import org.springframework.stereotype.Component;
+
+import com.househub.backend.domain.inquiry.entity.Inquiry;
+import com.househub.backend.domain.inquiry.entity.InquiryAnswer;
+import com.househub.backend.domain.inquiry.repository.InquiryAnswerRepository;
+import com.househub.backend.domain.inquiry.repository.InquiryRepository;
+import com.househub.backend.domain.inquiry.service.InquiryStore;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class InquiryStoreImpl implements InquiryStore {
+	private final InquiryRepository inquiryRepository;
+	private final InquiryAnswerRepository answerRepository;
+
+	@Override
+	public Inquiry save(Inquiry inquiry) {
+		return inquiryRepository.save(inquiry);
+	}
+
+	@Override
+	public void saveAnswer(InquiryAnswer inquiryAnswer) {
+		answerRepository.save(inquiryAnswer);
+	}
+}

--- a/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryStoreImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/service/impl/InquiryStoreImpl.java
@@ -17,12 +17,12 @@ public class InquiryStoreImpl implements InquiryStore {
 	private final InquiryAnswerRepository answerRepository;
 
 	@Override
-	public Inquiry save(Inquiry inquiry) {
+	public Inquiry create(Inquiry inquiry) {
 		return inquiryRepository.save(inquiry);
 	}
 
 	@Override
-	public void saveAnswer(InquiryAnswer inquiryAnswer) {
+	public void createAnswer(InquiryAnswer inquiryAnswer) {
 		answerRepository.save(inquiryAnswer);
 	}
 }

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/service/InquiryTemplateReader.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/service/InquiryTemplateReader.java
@@ -1,0 +1,7 @@
+package com.househub.backend.domain.inquiryTemplate.service;
+
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+
+public interface InquiryTemplateReader {
+	InquiryTemplate getValidTemplate(String templateToken);
+}

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/service/InquiryTemplateReader.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/service/InquiryTemplateReader.java
@@ -3,5 +3,5 @@ package com.househub.backend.domain.inquiryTemplate.service;
 import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
 
 public interface InquiryTemplateReader {
-	InquiryTemplate getValidTemplate(String templateToken);
+	InquiryTemplate findByToken(String templateToken);
 }

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/service/impl/InquiryTemplateReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/service/impl/InquiryTemplateReaderImpl.java
@@ -17,7 +17,7 @@ public class InquiryTemplateReaderImpl implements InquiryTemplateReader {
 	private final InquiryTemplateSharedTokenRepository sharedTokenRepository;
 
 	@Override
-	public InquiryTemplate getValidTemplate(String token) {
+	public InquiryTemplate findByToken(String token) {
 		InquiryTemplateSharedToken shareToken = sharedTokenRepository.findByShareTokenAndActiveTrue(token)
 			.orElseThrow(() -> new BusinessException(ErrorCode.INVALID_SHARED_TOKEN));
 

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/service/impl/InquiryTemplateReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/service/impl/InquiryTemplateReaderImpl.java
@@ -1,0 +1,26 @@
+package com.househub.backend.domain.inquiryTemplate.service.impl;
+
+import org.springframework.stereotype.Component;
+
+import com.househub.backend.common.exception.BusinessException;
+import com.househub.backend.common.exception.ErrorCode;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplate;
+import com.househub.backend.domain.inquiryTemplate.entity.InquiryTemplateSharedToken;
+import com.househub.backend.domain.inquiryTemplate.repository.InquiryTemplateSharedTokenRepository;
+import com.househub.backend.domain.inquiryTemplate.service.InquiryTemplateReader;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class InquiryTemplateReaderImpl implements InquiryTemplateReader {
+	private final InquiryTemplateSharedTokenRepository sharedTokenRepository;
+
+	@Override
+	public InquiryTemplate getValidTemplate(String token) {
+		InquiryTemplateSharedToken shareToken = sharedTokenRepository.findByShareTokenAndActiveTrue(token)
+			.orElseThrow(() -> new BusinessException(ErrorCode.INVALID_SHARED_TOKEN));
+
+		return shareToken.getTemplate();
+	}
+}


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 문의 등록하기 API 서비스 로직 리팩토링
- 문의 목록 조회 API 서비스 로직 리팩토링
- 문의 상세정보 조회 API 서비스 로직 리팩토링

## ✏️ 변경 사항
- Customer 엔티티에 잠재 고객('POTENTIAL')인지 활성화 고객('ACTIVE')인지 비활성화 고객('INACTIVE')인지 구분하는 status 컬럼 추가.
- 고객 생성 시 status 기본값은 'POTENTIAL'
- 연락처 기반 고객 조회 및 신규 고객 생성 로직 reader, store, executor 로 분리
- 고객 생성 시 연락처만 있어도 생성 가능
- 문의 및 문의 답변 로직 reader, store, executor 로 분리

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈
- 연관된 이슈가 있다면 연결해주세요. #130
