### PR TITLE
youngseok, feat: 전송 실패 문자 재전송 로직 배치로 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,18 @@ dependencies {
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
     runtimeOnly 'org.apache.logging.log4j:log4j-core:2.20.0'
 
+    // 스프링 배치 코어
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // 배치 테스트 지원
+    testImplementation 'org.springframework.batch:spring-batch-test'
+
+    // Quartz 스케줄러 (필요시)
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }
 
 tasks.named('test') {

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,15 @@
-version: '3.8'
-
 services:
-  househub-backend:
-    container_name: househub-backend
-    build:
-      context: .
-      dockerfile: Dockerfile
+  mysql-container:
+    image: mysql:8.0
+    container_name: mysql-container
+    environment:
+      MYSQL_ROOT_PASSWORD: root123
+      MYSQL_DATABASE: househub
     ports:
-      - "8080:8080"
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10

--- a/src/main/java/com/househub/backend/HouseHubBackendApplication.java
+++ b/src/main/java/com/househub/backend/HouseHubBackendApplication.java
@@ -4,12 +4,14 @@ import java.util.TimeZone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 import jakarta.annotation.PostConstruct;
 
 @SpringBootApplication
 @EnableRedisHttpSession // Redis를 세션저장소로 사용
+@EnableScheduling
 public class HouseHubBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/househub/backend/common/exception/GlobalExceptionHandler.java
@@ -160,4 +160,15 @@ public class GlobalExceptionHandler {
 			.build();
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
 	}
+
+	@ExceptionHandler(SmsSendFailException.class)
+	public ResponseEntity<ErrorResponse> handleSmsSendFailError(SmsSendFailException e) {
+		ErrorResponse response = ErrorResponse.builder()
+			.success(false)
+			.message(e.getMessage())
+			.code(e.getCode())
+			.errors(null)
+			.build();
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+	}
 }

--- a/src/main/java/com/househub/backend/common/exception/SmsSendFailException.java
+++ b/src/main/java/com/househub/backend/common/exception/SmsSendFailException.java
@@ -1,0 +1,17 @@
+package com.househub.backend.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import lombok.Getter;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+@Getter
+public class SmsSendFailException extends RuntimeException {
+	private final String code;
+
+	public SmsSendFailException(String message, String code) {
+		super(message);
+		this.code = code;
+	}
+}

--- a/src/main/java/com/househub/backend/domain/customer/dto/CreateCustomerReqDto.java
+++ b/src/main/java/com/househub/backend/domain/customer/dto/CreateCustomerReqDto.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreateCustomerReqDto {
 
-    @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하 여야 합니다.")
     private String name;
 
 	private Integer ageGroup;

--- a/src/main/java/com/househub/backend/domain/sms/dto/SendSmsReqDto.java
+++ b/src/main/java/com/househub/backend/domain/sms/dto/SendSmsReqDto.java
@@ -2,6 +2,7 @@ package com.househub.backend.domain.sms.dto;
 
 import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.sms.entity.Sms;
+import com.househub.backend.domain.sms.entity.SmsTemplate;
 import com.househub.backend.domain.sms.enums.MessageType;
 import com.househub.backend.domain.sms.enums.SmsStatus;
 
@@ -21,11 +22,9 @@ import lombok.Setter;
 public class SendSmsReqDto {
 
 	@NotEmpty(message = "발신번호를 입력해주세요")
-	@Pattern(regexp = "^[0-9]+$", message = "발신번호는 숫자만 입력 가능합니다")
 	private String sender;
 
 	@NotEmpty(message = "수신번호를 입력해주세요")
-	@Pattern(regexp = "^[0-9]+$", message = "수신번호는 숫자만 입력 가능합니다")
 	private String receiver;
 
 	@NotEmpty(message = "발신 내용을 입력해주세요")
@@ -43,7 +42,7 @@ public class SendSmsReqDto {
 
 	private Long templateId;
 
-	public Sms toEntity(SmsStatus status, Agent agent) {
+	public Sms toEntity(SmsStatus status, Agent agent, SmsTemplate template) {
 		return Sms.builder()
 			.sender(this.sender)
 			.receiver(this.receiver)
@@ -54,7 +53,7 @@ public class SendSmsReqDto {
 			.rdate(this.rdate)
 			.rtime(this.rtime)
 			.agent(agent)
-			.templateId(this.templateId)
+			.smsTemplate(template)
 			.build();
 	}
 
@@ -67,7 +66,6 @@ public class SendSmsReqDto {
 			.title(sms.getTitle())
 			.rdate(sms.getRdate())
 			.rtime(sms.getRtime())
-			.templateId(sms.getTemplateId())
 			.build();
 	}
 }

--- a/src/main/java/com/househub/backend/domain/sms/dto/SendSmsReqDto.java
+++ b/src/main/java/com/househub/backend/domain/sms/dto/SendSmsReqDto.java
@@ -58,11 +58,16 @@ public class SendSmsReqDto {
 			.build();
 	}
 
-	public void setSender(String sender) {
-		this.sender = sender != null ? sender.replaceAll("-", "") : null;
-	}
-
-	public void setReceiver(String receiver) {
-		this.receiver = receiver != null ? receiver.replaceAll("-", "") : null;
+	public static SendSmsReqDto fromEntity(Sms sms){
+		return SendSmsReqDto.builder()
+			.sender(sms.getSender())
+			.receiver(sms.getReceiver())
+			.msg(sms.getMsg())
+			.msgType(sms.getMsgType())
+			.title(sms.getTitle())
+			.rdate(sms.getRdate())
+			.rtime(sms.getRtime())
+			.templateId(sms.getTemplateId())
+			.build();
 	}
 }

--- a/src/main/java/com/househub/backend/domain/sms/entity/Sms.java
+++ b/src/main/java/com/househub/backend/domain/sms/entity/Sms.java
@@ -57,13 +57,15 @@ public class Sms {
 
 	private LocalDateTime deletedAt;
 
-	private Long templateId;
-
 	private Integer retryCount;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "agent_id", nullable = false)
 	private Agent agent;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sms_template_id")
+	private SmsTemplate smsTemplate;
 
 	@PrePersist
 	protected void onCreate() {

--- a/src/main/java/com/househub/backend/domain/sms/entity/Sms.java
+++ b/src/main/java/com/househub/backend/domain/sms/entity/Sms.java
@@ -59,6 +59,8 @@ public class Sms {
 
 	private Long templateId;
 
+	private Integer retryCount;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "agent_id", nullable = false)
 	private Agent agent;
@@ -72,5 +74,13 @@ public class Sms {
 	@PreUpdate
 	protected void onUpdate() {
 		updatedAt = LocalDateTime.now();
+	}
+
+	public void updateStatus(SmsStatus status) {
+		this.status = status;
+	}
+
+	public void incrementRetryCount() {
+		this.retryCount = (retryCount == null) ? 1 : retryCount + 1;
 	}
 }

--- a/src/main/java/com/househub/backend/domain/sms/enums/SmsStatus.java
+++ b/src/main/java/com/househub/backend/domain/sms/enums/SmsStatus.java
@@ -1,5 +1,5 @@
 package com.househub.backend.domain.sms.enums;
 
 public enum SmsStatus {
-	SUCCESS, FAIL
+	SUCCESS, FAIL, PERMANENT_FAIL
 }

--- a/src/main/java/com/househub/backend/domain/sms/job/SmsJobScheduler.java
+++ b/src/main/java/com/househub/backend/domain/sms/job/SmsJobScheduler.java
@@ -1,0 +1,36 @@
+package com.househub.backend.domain.sms.job;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SmsJobScheduler {
+
+	private final JobLauncher jobLauncher;
+
+	@Qualifier("smsResendJob")
+	private final Job smsResendJob;
+
+	@Scheduled(cron = "0 15 15 * * *")
+	public void runSmsResendJob() {
+		try {
+			JobParameters parameters = new JobParametersBuilder()
+				.addLong("time", System.currentTimeMillis())
+				.toJobParameters();
+
+			jobLauncher.run(smsResendJob, parameters);
+		} catch (Exception e) {
+			log.error("SMS 재전솜 Job 실행 실패", e);
+		}
+	}
+}

--- a/src/main/java/com/househub/backend/domain/sms/job/SmsJobScheduler.java
+++ b/src/main/java/com/househub/backend/domain/sms/job/SmsJobScheduler.java
@@ -21,16 +21,16 @@ public class SmsJobScheduler {
 	@Qualifier("smsResendJob")
 	private final Job smsResendJob;
 
-	@Scheduled(cron = "0 15 15 * * *")
+	@Scheduled(cron = "0 0/1 * * * *")
 	public void runSmsResendJob() {
 		try {
 			JobParameters parameters = new JobParametersBuilder()
-				.addLong("time", System.currentTimeMillis())
+				.addLong("runtime", System.currentTimeMillis())
 				.toJobParameters();
 
 			jobLauncher.run(smsResendJob, parameters);
 		} catch (Exception e) {
-			log.error("SMS 재전솜 Job 실행 실패", e);
+			log.error("Job 실행 실패: {}", e.getMessage());
 		}
 	}
 }

--- a/src/main/java/com/househub/backend/domain/sms/job/SmsJobScheduler.java
+++ b/src/main/java/com/househub/backend/domain/sms/job/SmsJobScheduler.java
@@ -33,4 +33,11 @@ public class SmsJobScheduler {
 			log.error("Job 실행 실패: {}", e.getMessage());
 		}
 	}
+
+	// 계약 종료일 3달 전인 고객에게 문자로 알림을 보냄
+
+
+	// 생일 대상자인 고객에게 축하 메세지 자동 전송
+
+
 }

--- a/src/main/java/com/househub/backend/domain/sms/job/SmsResendJobConfig.java
+++ b/src/main/java/com/househub/backend/domain/sms/job/SmsResendJobConfig.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class SmsJobConfig {
+public class SmsResendJobConfig {
 
 	private final JobRepository jobRepository;
 	private final PlatformTransactionManager transactionManager;  // ✅ 트랜잭션 매니저 주입
@@ -72,11 +72,11 @@ public class SmsJobConfig {
 	public ItemProcessor<Sms, Sms> smsResendProcessor(SmsExecutor smsExecutor, EntityManager entityManager) {
 		return sms -> {
 			Sms detachedSms = entityManager.merge(sms);
-			entityManager.detach(detachedSms); // ✅ 병합된 엔티티를 detach
+			entityManager.detach(detachedSms);
 
 			boolean result = smsExecutor.resend(detachedSms);
-			detachedSms.updateStatus((result ? SmsStatus.SUCCESS : SmsStatus.FAIL)); // ✅ detachedSms에 상태 업데이트
-			detachedSms.incrementRetryCount(); // ✅ detachedSms에 카운트 증가
+			detachedSms.updateStatus((result ? SmsStatus.SUCCESS : SmsStatus.FAIL));
+			detachedSms.incrementRetryCount();
 			if(!result && detachedSms.getRetryCount() > 3) {
 				detachedSms.updateStatus(SmsStatus.PERMANENT_FAIL);
 			}
@@ -99,4 +99,3 @@ public class SmsJobConfig {
 	}
 
 }
-

--- a/src/main/java/com/househub/backend/domain/sms/job/SmsResendJobConfig.java
+++ b/src/main/java/com/househub/backend/domain/sms/job/SmsResendJobConfig.java
@@ -1,0 +1,102 @@
+package com.househub.backend.domain.sms.job;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.househub.backend.domain.sms.entity.Sms;
+import com.househub.backend.domain.sms.enums.SmsStatus;
+import com.househub.backend.domain.sms.service.SmsExecutor;
+import com.househub.backend.domain.sms.service.SmsReader;
+import com.househub.backend.domain.sms.service.SmsStore;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class SmsJobConfig {
+
+	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;  // ✅ 트랜잭션 매니저 주입
+
+	@Bean("smsResendJob")
+	public Job smsResendJob(Step smsResendStep) {
+		return new JobBuilder("smsResendJob", jobRepository)
+			.incrementer(new RunIdIncrementer())
+			.start(smsResendStep)
+			.build();
+	}
+
+	@Bean
+	public Step smsResendStep(
+		ItemReader<Sms> smsFailLogReader,
+		ItemProcessor<Sms, Sms> smsResendProcessor,
+		ItemWriter<Sms> smsLogWriter
+	) {
+		return new StepBuilder("smsResendStep", jobRepository)
+			.<Sms, Sms>chunk(100, transactionManager)  // 청크 크기 설정
+			.reader(smsFailLogReader)
+			.processor(smsResendProcessor)
+			.writer(smsLogWriter)
+			.build();
+	}
+
+	@Bean
+	@StepScope  // ✅ Step 실행 시점에 빈 생성
+	public ItemReader<Sms> smsFailLogReader(SmsReader smsReader) {
+		List<Sms> data = smsReader.findFailLogsForResend();
+		log.info("재전송 대상 SMS 건수: {}", data.size());
+		return new ListItemReader<>(data);
+	}
+
+	@Bean
+	@StepScope
+	public ItemProcessor<Sms, Sms> smsResendProcessor(SmsExecutor smsExecutor, EntityManager entityManager) {
+		return sms -> {
+			Sms detachedSms = entityManager.merge(sms);
+			entityManager.detach(detachedSms); // ✅ 병합된 엔티티를 detach
+
+			boolean result = smsExecutor.resend(detachedSms);
+			detachedSms.updateStatus((result ? SmsStatus.SUCCESS : SmsStatus.FAIL)); // ✅ detachedSms에 상태 업데이트
+			detachedSms.incrementRetryCount(); // ✅ detachedSms에 카운트 증가
+			if(!result && detachedSms.getRetryCount() > 3) {
+				detachedSms.updateStatus(SmsStatus.PERMANENT_FAIL);
+			}
+			return detachedSms;
+		};
+	}
+
+
+	@Bean
+	@StepScope
+	public ItemWriter<Sms> smsLogWriter(SmsStore smsStore, EntityManager entityManager) {
+		return items -> {
+			// ✅ detached 엔티티 병합 후 저장
+			List<Sms> mergedSmsList = items.getItems().stream()
+				.map(entityManager::merge)
+				.collect(Collectors.toCollection(ArrayList::new));
+
+			smsStore.updateAll(mergedSmsList);
+		};
+	}
+
+}
+

--- a/src/main/java/com/househub/backend/domain/sms/repository/SmsRepository.java
+++ b/src/main/java/com/househub/backend/domain/sms/repository/SmsRepository.java
@@ -1,5 +1,7 @@
 package com.househub.backend.domain.sms.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.househub.backend.domain.sms.entity.Sms;
+import com.househub.backend.domain.sms.enums.SmsStatus;
 
 public interface SmsRepository extends JpaRepository<Sms, Long> {
 
@@ -23,4 +26,6 @@ public interface SmsRepository extends JpaRepository<Sms, Long> {
 		") " +
 		"ORDER BY s.createdAt DESC")
 	Page<Sms> findAllSmsByAgentIdAndFiltersAndDeletedAtIsNull(@Param("agentId") Long agentId,@Param("receiver") String receiver,@Param("msg") String msg, Pageable pageable);
+
+	List<Sms> findSmsByStatus(SmsStatus status);
 }

--- a/src/main/java/com/househub/backend/domain/sms/service/SmsExecutor.java
+++ b/src/main/java/com/househub/backend/domain/sms/service/SmsExecutor.java
@@ -1,0 +1,7 @@
+package com.househub.backend.domain.sms.service;
+
+import com.househub.backend.domain.sms.entity.Sms;
+
+public interface SmsExecutor {
+	boolean resend(Sms log);
+}

--- a/src/main/java/com/househub/backend/domain/sms/service/SmsReader.java
+++ b/src/main/java/com/househub/backend/domain/sms/service/SmsReader.java
@@ -1,11 +1,16 @@
 package com.househub.backend.domain.sms.service;
 
+import java.util.List;
+
+import org.springframework.batch.item.ItemReader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.househub.backend.domain.sms.entity.Sms;
+import com.househub.backend.domain.sms.repository.SmsRepository;
 
 public interface SmsReader {
 	Page<Sms> findAllByKeyword(Long agentId, String receiver, String msg, Pageable pageable);
 	Sms findById(Long id, Long agentId);
+	List<Sms> findFailLogsForResend();
 }

--- a/src/main/java/com/househub/backend/domain/sms/service/SmsStore.java
+++ b/src/main/java/com/househub/backend/domain/sms/service/SmsStore.java
@@ -1,7 +1,10 @@
 package com.househub.backend.domain.sms.service;
 
+import java.util.List;
+
 import com.househub.backend.domain.sms.entity.Sms;
 
 public interface SmsStore {
 	Sms create(Sms sms);
+	void updateAll(List<? extends Sms> logs);
 }

--- a/src/main/java/com/househub/backend/domain/sms/service/impl/SmsExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/sms/service/impl/SmsExecutorImpl.java
@@ -1,0 +1,24 @@
+package com.househub.backend.domain.sms.service.impl;
+
+import org.springframework.stereotype.Component;
+
+import com.househub.backend.domain.sms.dto.AligoSmsResDto;
+import com.househub.backend.domain.sms.dto.SendSmsReqDto;
+import com.househub.backend.domain.sms.entity.Sms;
+import com.househub.backend.domain.sms.service.AligoService;
+import com.househub.backend.domain.sms.service.SmsExecutor;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SmsExecutorImpl implements SmsExecutor {
+
+	private final AligoService aligoService;
+
+	@Override
+	public boolean resend(Sms log) {
+		AligoSmsResDto result = aligoService.sendSms(SendSmsReqDto.fromEntity(log));
+		return result.getResultCode() == 1;
+	}
+}

--- a/src/main/java/com/househub/backend/domain/sms/service/impl/SmsReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/sms/service/impl/SmsReaderImpl.java
@@ -1,10 +1,15 @@
 package com.househub.backend.domain.sms.service.impl;
 
+import java.util.List;
+
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import com.househub.backend.domain.sms.entity.Sms;
+import com.househub.backend.domain.sms.enums.SmsStatus;
 import com.househub.backend.domain.sms.repository.SmsRepository;
 import com.househub.backend.domain.sms.service.SmsReader;
 
@@ -25,5 +30,10 @@ public class SmsReaderImpl implements SmsReader {
 	@Override
 	public Sms findById(Long id, Long agentId) {
 		return smsRepository.findByIdAndAgentId(id, agentId);
+	}
+
+	@Override
+	public List<Sms> findFailLogsForResend() {
+		return smsRepository.findSmsByStatus(SmsStatus.FAIL);
 	}
 }

--- a/src/main/java/com/househub/backend/domain/sms/service/impl/SmsServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/sms/service/impl/SmsServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import com.househub.backend.common.exception.SmsSendFailException;
 import com.househub.backend.domain.agent.dto.AgentResDto;
 import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.sms.dto.AligoHistoryResDto;
@@ -15,6 +16,7 @@ import com.househub.backend.domain.sms.dto.SendSmsResDto;
 import com.househub.backend.domain.sms.dto.SmsListResDto;
 import com.househub.backend.domain.sms.entity.Sms;
 import com.househub.backend.domain.sms.enums.SmsStatus;
+import com.househub.backend.domain.sms.service.AligoService;
 import com.househub.backend.domain.sms.service.SmsReader;
 import com.househub.backend.domain.sms.service.SmsService;
 import com.househub.backend.domain.sms.service.SmsStore;
@@ -25,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SmsServiceImpl implements SmsService {
 
-	private final AligoServiceImpl aligoService;
+	private final AligoService aligoService;
 	private final SmsStore smsStore;
 	private final SmsReader smsReader;
 
@@ -36,7 +38,8 @@ public class SmsServiceImpl implements SmsService {
 		if(aligoResponse.getResultCode() == 1){
 			return SendSmsResDto.fromEntity(smsStore.create(request.toEntity(SmsStatus.SUCCESS,agent)));
 		} else {
-			return SendSmsResDto.fromEntity(smsStore.create(request.toEntity(SmsStatus.FAIL,agent)));
+			smsStore.create(request.toEntity(SmsStatus.FAIL,agent));
+			throw new SmsSendFailException(aligoResponse.getMessage(),"SMS_SEND_FAIL");
 		}
 	}
 	

--- a/src/main/java/com/househub/backend/domain/sms/service/impl/SmsServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/sms/service/impl/SmsServiceImpl.java
@@ -15,11 +15,13 @@ import com.househub.backend.domain.sms.dto.SendSmsReqDto;
 import com.househub.backend.domain.sms.dto.SendSmsResDto;
 import com.househub.backend.domain.sms.dto.SmsListResDto;
 import com.househub.backend.domain.sms.entity.Sms;
+import com.househub.backend.domain.sms.entity.SmsTemplate;
 import com.househub.backend.domain.sms.enums.SmsStatus;
 import com.househub.backend.domain.sms.service.AligoService;
 import com.househub.backend.domain.sms.service.SmsReader;
 import com.househub.backend.domain.sms.service.SmsService;
 import com.househub.backend.domain.sms.service.SmsStore;
+import com.househub.backend.domain.sms.service.SmsTemplateReader;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,15 +32,17 @@ public class SmsServiceImpl implements SmsService {
 	private final AligoService aligoService;
 	private final SmsStore smsStore;
 	private final SmsReader smsReader;
+	private final SmsTemplateReader smsTemplateReader;
 
 	// send와 create 분리
 	public SendSmsResDto sendSms(SendSmsReqDto request, AgentResDto agentDto) {
 		Agent agent = agentDto.toEntity();
 		AligoSmsResDto aligoResponse = aligoService.sendSms(request);
+		SmsTemplate template = smsTemplateReader.findById(request.getTemplateId(),agent.getId());
 		if(aligoResponse.getResultCode() == 1){
-			return SendSmsResDto.fromEntity(smsStore.create(request.toEntity(SmsStatus.SUCCESS,agent)));
+			return SendSmsResDto.fromEntity(smsStore.create(request.toEntity(SmsStatus.SUCCESS,agent,template)));
 		} else {
-			smsStore.create(request.toEntity(SmsStatus.FAIL,agent));
+			smsStore.create(request.toEntity(SmsStatus.FAIL,agent,template));
 			throw new SmsSendFailException(aligoResponse.getMessage(),"SMS_SEND_FAIL");
 		}
 	}

--- a/src/main/java/com/househub/backend/domain/sms/service/impl/SmsStoreImpl.java
+++ b/src/main/java/com/househub/backend/domain/sms/service/impl/SmsStoreImpl.java
@@ -1,5 +1,8 @@
 package com.househub.backend.domain.sms.service.impl;
 
+import java.util.List;
+
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.stereotype.Component;
 
 import com.househub.backend.domain.sms.entity.Sms;
@@ -17,5 +20,11 @@ public class SmsStoreImpl implements SmsStore {
 	@Override
 	public Sms create(Sms sms) {
 		return smsRepository.save(sms);
+	}
+
+	@StepScope
+	@Override
+	public void updateAll(List<? extends Sms> logs) {
+		smsRepository.saveAll(logs);
 	}
 }


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 문자 전송 시 사용된 템플릿 정보를 문자 데이터에 저장하여, 문자 목록에서 템플릿 기반 필터링이 가능하도록 기능을 추가하였습니다.
- 문자 발송 실패 시 3회 재전송 후에도 실패하면 '영구 실패' 상태로 전환되도록 로직을 개선하고, 관련 API 및 응답에 적용하였습니다.

## ✏️ 변경 사항
- 문자 전송 시 템플릿 정보(식별자 등)를 문자 엔티티에 함께 저장
- 문자 목록 조회 API에 템플릿 필터링 기능 추가
- 중개업자가 생성한 템플릿이 없는 경우, 템플릿 선택 필드가 '템플릿 추가'로 대체되도록 API 응답 구조 개선
- 문자 발송 실패 시 최대 3회까지 재전송 시도, 이후에도 실패하면 문자 상태를 'PERMANENT_FAILED(영구 실패)'로 변경
- 문자 상태값에 'PERMANENT_FAILED' 추가 및 관련 비즈니스 로직/엔티티/응답에 반영

## 📸 스크린샷 (선택사항)
- (API 응답 예시 또는 상태값 변경 관련 스크린샷이 있다면 첨부)

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [x] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #141
- #146
