### PR TITLE
hyunho, feat: 크롤링 매물 태그 검색 기능 추가 #166

### DIFF
--- a/src/main/java/com/househub/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/househub/backend/common/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
 	MISSING_CUSTOMER_INFORMATION(HttpStatus.BAD_REQUEST, "MISSING_CUSTOMER_INFORMATION",
 		"기존 고객 ID 또는 신규 고객 정보 중 하나는 필수입니다."),
 	CONFLICT_CUSTOMER_CONTACT(HttpStatus.CONFLICT,
-		"CONFLICT_CUSTOMER_CONTACT", "이미 등록된 연락처입니다. 기존 고객을 찾아 선택하세요.");
+		"CONFLICT_CUSTOMER_CONTACT", "이미 등록된 연락처입니다. 기존 고객을 찾아 선택하세요."),
 	INVALID_INQUIRY_TYPE(HttpStatus.BAD_REQUEST, "INVALID_INQUIRY_TYPE", "유효하지 않은 문의 유형입니다."),
 	INVALID_INQUIRY_TEMPLATE_TITLE_MODIFICATION(
 		HttpStatus.BAD_REQUEST,

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/controller/CrawlingPropertyController.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/controller/CrawlingPropertyController.java
@@ -1,17 +1,22 @@
 package com.househub.backend.domain.crawlingProperty.controller;
 
 import com.househub.backend.common.response.SuccessResponse;
+import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyListResDto;
 import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyReqDto;
 import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyResDto;
+import com.househub.backend.domain.crawlingProperty.entity.CrawlingProperty;
 import com.househub.backend.domain.crawlingProperty.service.CrawlingPropertyService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/crawlingProperties")
@@ -19,8 +24,8 @@ public class CrawlingPropertyController {
 
     private final CrawlingPropertyService crawlingPropertyService;
 
-    @GetMapping("/")
-    public ResponseEntity<SuccessResponse<List<CrawlingPropertyResDto>>> findAllCrawlingProperty(
+    @GetMapping("")
+    public ResponseEntity<SuccessResponse<CrawlingPropertyListResDto>> findAllCrawlingProperty(
         @ModelAttribute CrawlingPropertyReqDto crawlingPropertyReqDto,
         Pageable pageable
     ) {
@@ -30,7 +35,30 @@ public class CrawlingPropertyController {
 
         Pageable adjustedPageable = PageRequest.of(page, size, pageable.getSort());
 
-        List<CrawlingPropertyResDto> response = crawlingPropertyService.findAll(crawlingPropertyReqDto, adjustedPageable);
+        CrawlingPropertyListResDto response = crawlingPropertyService.findAll(crawlingPropertyReqDto, adjustedPageable);
+        return ResponseEntity.ok(SuccessResponse.success("크롤링 매물 목록 조회에 성공했습니다.", "FIND_CRAWLING_PROPERTY_SUCCESS", response));
+    }
+
+
+    @GetMapping("/tags")
+    public ResponseEntity<SuccessResponse<CrawlingPropertyListResDto>> findAllCrawlingPropertyWithTags(
+        @RequestParam List<Long> tagIds,
+        @ModelAttribute CrawlingPropertyReqDto crawlingPropertyReqDto,
+        Pageable pageable
+    ) {
+        log.info("{}", tagIds);
+        log.info("{}", tagIds.get(0));
+        // page를 1-based에서 0-based로 변경
+        int page = Math.max(pageable.getPageNumber() - 1, 0);
+        int size = pageable.getPageSize();
+
+        Pageable adjustedPageable = PageRequest.of(page, size, pageable.getSort());
+
+        CrawlingPropertyListResDto response = crawlingPropertyService.findPropertiesByTags(
+            tagIds,
+            crawlingPropertyReqDto,
+            adjustedPageable
+        );
         return ResponseEntity.ok(SuccessResponse.success("크롤링 매물 목록 조회에 성공했습니다.", "FIND_CRAWLING_PROPERTY_SUCCESS", response));
     }
 
@@ -41,4 +69,28 @@ public class CrawlingPropertyController {
         CrawlingPropertyResDto response = crawlingPropertyService.findOne(id);
         return ResponseEntity.ok(SuccessResponse.success("크롤링 매물 상세 조회에 성공했습니다.", "FIND_CRAWLING_PROPERTY_SUCCESS", response));
     }
+
+
+
+//    @GetMapping("/tags")
+//    public ResponseEntity<SuccessResponse<CrawlingPropertyListResDto>> findAllCrawlingPropertyWithTags(
+//        @RequestParam List<Long> tagIds,
+//        @ModelAttribute CrawlingPropertyReqDto crawlingPropertyReqDto,
+//        Pageable pageable
+//    ) {
+//        log.info("{}", tagIds);
+//        log.info("{}", tagIds.get(0));
+//        // page를 1-based에서 0-based로 변경
+//        int page = Math.max(pageable.getPageNumber() - 1, 0);
+//        int size = pageable.getPageSize();
+//
+//        Pageable adjustedPageable = PageRequest.of(page, size, pageable.getSort());
+//
+//        CrawlingPropertyListResDto response = crawlingPropertyService.findPropertiesByTags2(
+//            tagIds,
+//            crawlingPropertyReqDto,
+//            adjustedPageable
+//        );
+//        return ResponseEntity.ok(SuccessResponse.success("크롤링 매물 목록 조회에 성공했습니다.", "FIND_CRAWLING_PROPERTY_SUCCESS", response));
+//    }
 }

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/controller/CrawlingTagController.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/controller/CrawlingTagController.java
@@ -1,0 +1,27 @@
+package com.househub.backend.domain.crawlingProperty.controller;
+
+import com.househub.backend.common.response.SuccessResponse;
+import com.househub.backend.domain.crawlingProperty.dto.CrawlingTagResDto;
+import com.househub.backend.domain.crawlingProperty.service.CrawlingTagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/crawlingTag")
+public class CrawlingTagController {
+
+    private final CrawlingTagService crawlingTagService;
+
+    @GetMapping("")
+    public ResponseEntity<SuccessResponse<List<CrawlingTagResDto>>> findAllTags() {
+        List<CrawlingTagResDto> response = crawlingTagService.findAll();
+
+        return ResponseEntity.ok(SuccessResponse.success("태그 목록 조회에 성공했습니다.", "FIND_TAG_SUCCESS", response));
+    }
+}

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/dto/CrawlingPropertyReqDto.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/dto/CrawlingPropertyReqDto.java
@@ -4,6 +4,8 @@ import com.househub.backend.domain.crawlingProperty.enums.PropertyType;
 import com.househub.backend.domain.crawlingProperty.enums.TransactionType;
 import lombok.*;
 
+import java.util.List;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -39,22 +41,6 @@ public class CrawlingPropertyReqDto {
 
     private Float maxMonthlyRent;
 
-    public Object[] searchArgs() {
-        return new Object[] {
-            this.propertyType,
-            this.transactionType,
-            this.province,
-            this.city,
-            this.dong,
-            this.detailAddress,
-            this.minArea,
-            this.maxArea,
-            this.minSalePrice,
-            this.maxSalePrice,
-            this.minDeposit,
-            this.maxDeposit,
-            this.minMonthlyRent,
-            this.maxMonthlyRent
-        };
-    }
+    private List<Long> tagIds;
+
 }

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/dto/CrawlingPropertyResDto.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/dto/CrawlingPropertyResDto.java
@@ -1,11 +1,15 @@
 package com.househub.backend.domain.crawlingProperty.dto;
 
 import com.househub.backend.domain.crawlingProperty.entity.CrawlingProperty;
+import com.househub.backend.domain.crawlingProperty.entity.Tag;
 import com.househub.backend.domain.crawlingProperty.enums.Direction;
 import com.househub.backend.domain.crawlingProperty.enums.PropertyType;
 import com.househub.backend.domain.crawlingProperty.enums.TransactionType;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
 
 @Builder
 @Getter
@@ -23,9 +27,9 @@ public class CrawlingPropertyResDto {
     private Float area;
     private String floor;
     private String allFloors;
-    private Float salePrice;
-    private Float deposit;
-    private Float monthlyRentFee;
+    private String salePrice;
+    private String deposit;
+    private String monthlyRentFee;
     private Direction direction;
     private Integer bathRoomCnt;
     private Integer roomCnt;
@@ -35,6 +39,54 @@ public class CrawlingPropertyResDto {
     private String realEstateAgentContact;
     private String realEstateOfficeName;
     private String realEstateOfficeAddress;
+
+
+//    // 새로 추가한 부분
+//    private List<TagDto> tags; // 태그 리스트
+//
+//    @Getter
+//    @Builder
+//    public static class TagDto {
+//        private Long tagId;
+//        private String type;
+//        private String value;
+//    }
+//
+//    public static CrawlingPropertyResDto fromEntity(CrawlingProperty crawlingProperty, Map<String, List<Tag>> propertyTagsMap) {
+//        return CrawlingPropertyResDto.builder()
+//                .crawlingPropertiesId(crawlingProperty.getCrawlingPropertiesId())
+//                .propertyType(crawlingProperty.getPropertyType())
+//                .transactionType(crawlingProperty.getTransactionType())
+//                .province(crawlingProperty.getProvince())
+//                .city(crawlingProperty.getCity())
+//                .dong(crawlingProperty.getDong())
+//                .detailAddress(crawlingProperty.getDetailAddress())
+//                .area(crawlingProperty.getArea())
+//                .floor(crawlingProperty.getFloor())
+//                .allFloors(crawlingProperty.getAllFloors())
+//                .salePrice(convertPriceFormat(crawlingProperty.getSalePrice())) // 가격 문자 형식으로 변환하여 반환
+//                .deposit(convertPriceFormat(crawlingProperty.getDeposit())) // 가격 문자 형식으로 변환하여 반환
+//                .monthlyRentFee(convertPriceFormat(crawlingProperty.getMonthlyRentFee())) // 가격 문자 형식으로 변환하여 반환
+//                .direction(crawlingProperty.getDirection())
+//                .bathRoomCnt(crawlingProperty.getBathRoomCnt())
+//                .roomCnt(crawlingProperty.getRoomCnt())
+//                .realEstateAgentId(crawlingProperty.getRealEstateAgentId())
+//                .realEstateAgentName(crawlingProperty.getRealEstateAgentName())
+//                .realEstateAgentContact(crawlingProperty.getRealEstateAgentContact())
+//                .realEstateOfficeName(crawlingProperty.getRealEstateOfficeName())
+//                .realEstateOfficeAddress(crawlingProperty.getRealEstateOfficeAddress())
+//                .tags(
+//                        propertyTagsMap.getOrDefault(crawlingProperty.getCrawlingPropertiesId(), List.of())
+//                                .stream()
+//                                .map(tagEntity -> TagDto.builder()
+//                                        .tagId(tagEntity.getTagId())
+//                                        .type(tagEntity.getType())
+//                                        .value(tagEntity.getValue())
+//                                        .build())
+//                                .toList()
+//                )
+//                .build();
+//    }
 
     public static CrawlingPropertyResDto fromEntity(CrawlingProperty crawlingProperty) {
         return CrawlingPropertyResDto.builder()
@@ -48,9 +100,9 @@ public class CrawlingPropertyResDto {
                 .area(crawlingProperty.getArea())
                 .floor(crawlingProperty.getFloor())
                 .allFloors(crawlingProperty.getAllFloors())
-                .salePrice(crawlingProperty.getSalePrice())
-                .deposit(crawlingProperty.getDeposit())
-                .monthlyRentFee(crawlingProperty.getMonthlyRentFee())
+                .salePrice(convertPriceFormat(crawlingProperty.getSalePrice())) // 가격 문자 형식으로 변환하여 반환
+                .deposit(convertPriceFormat(crawlingProperty.getDeposit())) // 가격 문자 형식으로 변환하여 반환
+                .monthlyRentFee(convertPriceFormat(crawlingProperty.getMonthlyRentFee())) // 가격 문자 형식으로 변환하여 반환
                 .direction(crawlingProperty.getDirection())
                 .bathRoomCnt(crawlingProperty.getBathRoomCnt())
                 .roomCnt(crawlingProperty.getRoomCnt())
@@ -60,5 +112,46 @@ public class CrawlingPropertyResDto {
                 .realEstateOfficeName(crawlingProperty.getRealEstateOfficeName())
                 .realEstateOfficeAddress(crawlingProperty.getRealEstateOfficeAddress())
                 .build();
+    }
+
+    private static String convertPriceFormat(Float price) {
+
+        if (price == null) return null;
+
+        String convertedPrice, upperNumber, lowerNumber;
+
+        long longPrice = price.longValue();
+        String strPrice = String.valueOf(longPrice);
+
+        int lenPrice = strPrice.length();
+        if (lenPrice >= 5) { // 억단위 이상인 경우 처리
+            upperNumber = strPrice.substring(0, lenPrice - 4);
+            upperNumber = addComma(upperNumber) + "억 ";
+            strPrice = strPrice.substring(lenPrice - 4);
+        } else {
+            upperNumber = "";
+        }
+        // 천만원 이하의 경우 처리
+        if (strPrice.equals("0000")) {
+            lowerNumber = "";
+        } else {
+            lowerNumber = addComma(String.valueOf(Integer.parseInt(strPrice)));
+        }
+
+        // 문자 합산
+        convertedPrice = upperNumber + lowerNumber;
+
+        return convertedPrice;
+    }
+
+    private static String addComma(String price) {
+        String result;
+
+        if (price.length() == 4) {
+            result = price.substring(0, 1) + "," + price.substring(1);
+        } else {
+            result = price;
+        }
+        return result;
     }
 }

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/dto/CrawlingTagResDto.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/dto/CrawlingTagResDto.java
@@ -1,0 +1,22 @@
+package com.househub.backend.domain.crawlingProperty.dto;
+
+import com.househub.backend.domain.crawlingProperty.entity.Tag;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CrawlingTagResDto {
+
+    private Long tagId;
+    private String type;
+    private String value;
+
+    public static CrawlingTagResDto fromEntity(Tag tag) {
+        return CrawlingTagResDto.builder()
+                .tagId(tag.getTagId())
+                .type(tag.getType())
+                .value(tag.getValue())
+                .build();
+    }
+}

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/entity/CrawlingProperty.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/entity/CrawlingProperty.java
@@ -9,6 +9,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "crawling_properties")
 @AllArgsConstructor
@@ -68,4 +71,7 @@ public class CrawlingProperty {
     private Integer bathRoomCnt;
 
     private Integer roomCnt;
+
+    @OneToMany(mappedBy = "crawlingProperty")
+    private List<CrawlingPropertyTagMap> crawlingPropertyTagMaps = new ArrayList<>();
 }

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/entity/CrawlingPropertyTagMap.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/entity/CrawlingPropertyTagMap.java
@@ -1,26 +1,32 @@
-//package com.househub.backend.domain.crawlingProperty.entity;
-//
-//import jakarta.persistence.*;
-//import lombok.AllArgsConstructor;
-//import lombok.Builder;
-//import lombok.Getter;
-//import lombok.NoArgsConstructor;
-//
-//@Entity
-//@Table(name = "crawling_property_tag_map")
-//@AllArgsConstructor
-//@NoArgsConstructor
-//@Getter
-//@Builder
-//public class CrawlingPropertyTagMap {
-//
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
-//    private Long id;
-//
-//    @Column(nullable = false)
-//    private String crawlingPropertiesId;
-//
-//    @Column(nullable = false)
-//    private Long tag_id;
-//}
+package com.househub.backend.domain.crawlingProperty.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "crawling_property_tag_map")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class CrawlingPropertyTagMap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "crawling_properties_id", nullable = false)
+    @JsonIgnore
+    private CrawlingProperty crawlingProperty;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+}

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/entity/Tag.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/entity/Tag.java
@@ -1,26 +1,26 @@
-//package com.househub.backend.domain.crawlingProperty.entity;
-//
-//import jakarta.persistence.*;
-//import lombok.AllArgsConstructor;
-//import lombok.Builder;
-//import lombok.Getter;
-//import lombok.NoArgsConstructor;
-//
-//@Entity
-//@Table(name = "tags")
-//@AllArgsConstructor
-//@NoArgsConstructor
-//@Getter
-//@Builder
-//public class Tag {
-//
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
-//    private Long id;
-//
-//    @Column(nullable = false)
-//    private String type;
-//
-//    @Column(nullable = false)
-//    private String value;
-//}
+package com.househub.backend.domain.crawlingProperty.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tags")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tagId;
+
+    @Column(nullable = false)
+    private String type;
+
+    @Column(nullable = false)
+    private String value;
+}

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/enums/PropertyType.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/enums/PropertyType.java
@@ -1,5 +1,6 @@
 package com.househub.backend.domain.crawlingProperty.enums;
 
 public enum PropertyType {
-    VILLA, APARTMENT, OFFICETEL
+    MULTIFAMILY, SINGLEMULTIFAMILY, VILLA, COMMERCIAL, APARTMENT,
+    ROWHOUSE, OFFICETEL, ONE_ROOM, COUNTRYHOUSE
 }

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepository.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepository.java
@@ -1,6 +1,7 @@
 package com.househub.backend.domain.crawlingProperty.repository;
 
 import com.househub.backend.domain.crawlingProperty.entity.CrawlingProperty;
+import com.househub.backend.domain.crawlingProperty.enums.PropertyType;
 import com.househub.backend.domain.crawlingProperty.enums.TransactionType;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
@@ -8,24 +9,74 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
-public interface CrawlingPropertyRepository extends JpaRepository<CrawlingProperty, String> {
+public interface CrawlingPropertyRepository extends JpaRepository<CrawlingProperty, String>, CrawlingPropertyRepositoryCustom {
 
     // findAll
-    @Query("SELECT cp FROM CrawlingProperty cp " +
-            "WHERE (:transactionType IS NULL OR cp.transactionType = :transactionType) " +
-            "AND (:province IS NULL OR cp.province = :province) " +
-            "AND (:city IS NULL OR cp.city = :city) " +
-            "AND (:dong IS NULL OR cp.dong LIKE %:#{#dong}%)")
+    @Query(
+            "SELECT cp " +
+                    "FROM CrawlingProperty cp " +
+                    "WHERE (:transactionType IS NULL OR cp.transactionType = :transactionType) " +
+                    "AND (:propertyType IS NULL OR cp.propertyType = :propertyType) " +
+                    "AND (:province IS NULL OR cp.province = :province) " +
+                    "AND (:city IS NULL OR cp.city = :city) " +
+                    "AND (:dong IS NULL OR cp.dong LIKE CONCAT('%', :dong, '%')) " +
+                    "AND (:minSalePrice IS NULL OR cp.salePrice >= :minSalePrice) " +
+                    "AND (:maxSalePrice IS NULL OR cp.salePrice <= :maxSalePrice) " +
+                    "AND (:minDeposit IS NULL OR cp.deposit >= :minDeposit) " +
+                    "AND (:maxDeposit IS NULL OR cp.deposit <= :maxDeposit) " +
+                    "AND (:minMonthlyRentFee IS NULL OR cp.monthlyRentFee >= :minMonthlyRentFee) " +
+                    "AND (:maxMonthlyRentFee IS NULL OR cp.monthlyRentFee <= :maxMonthlyRentFee) "
+    )
     Page<CrawlingProperty> findByDto(
             @Param("transactionType") TransactionType transactionType,
+            @Param("propertyType") PropertyType propertyType,
             @Param("province") String province,
             @Param("city") String city,
             @Param("dong") String dong,
+            @Param("minSalePrice") Float minSalePrice,
+            @Param("maxSalePrice") Float maxSalePrice,
+            @Param("minDeposit") Float minDeposit,
+            @Param("maxDeposit") Float maxDeposit,
+            @Param("minMonthlyRentFee") Float minMonthlyRentFee,
+            @Param("maxMonthlyRentFee") Float maxMonthlyRentFee,
             Pageable pageable
     );
 
     // findOne
     Optional<CrawlingProperty> findById(String id);
+
+
+
+    // 임시로 만든 검색 코드
+    @Query(
+            "SELECT cp " +
+                    "FROM CrawlingProperty cp " +
+                    "WHERE (:transactionType IS NULL OR cp.transactionType = :transactionType) " +
+                    "AND (:propertyType IS NULL OR cp.propertyType = :propertyType) " +
+                    "AND (:province IS NULL OR cp.province = :province) " +
+                    "AND (:city IS NULL OR cp.city = :city) " +
+                    "AND (:dong IS NULL OR cp.dong LIKE CONCAT('%', :dong, '%')) " +
+                    "AND (:minSalePrice IS NULL OR cp.salePrice >= :minSalePrice) " +
+                    "AND (:maxSalePrice IS NULL OR cp.salePrice <= :maxSalePrice) " +
+                    "AND (:minDeposit IS NULL OR cp.deposit >= :minDeposit) " +
+                    "AND (:maxDeposit IS NULL OR cp.deposit <= :maxDeposit) " +
+                    "AND (:minMonthlyRentFee IS NULL OR cp.monthlyRentFee >= :minMonthlyRentFee) " +
+                    "AND (:maxMonthlyRentFee IS NULL OR cp.monthlyRentFee <= :maxMonthlyRentFee) "
+    )
+    List<CrawlingProperty> findByDto2(
+            @Param("transactionType") TransactionType transactionType,
+            @Param("propertyType") PropertyType propertyType,
+            @Param("province") String province,
+            @Param("city") String city,
+            @Param("dong") String dong,
+            @Param("minSalePrice") Float minSalePrice,
+            @Param("maxSalePrice") Float maxSalePrice,
+            @Param("minDeposit") Float minDeposit,
+            @Param("maxDeposit") Float maxDeposit,
+            @Param("minMonthlyRentFee") Float minMonthlyRentFee,
+            @Param("maxMonthlyRentFee") Float maxMonthlyRentFee
+    );
 }

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepositoryCustom.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.househub.backend.domain.crawlingProperty.repository;
+
+import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyResDto;
+import com.househub.backend.domain.crawlingProperty.entity.CrawlingProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CrawlingPropertyRepositoryCustom {
+    Page<CrawlingProperty> findByAnyMatchingTags(List<String> propertyIds, List<Long> tagIds, Pageable pageable);
+
+//    Page<CrawlingPropertyResDto> findByAnyMatchingTags2(List<String> propertyIds, List<Long> tagIds, Pageable pageable);
+}

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepositoryImpl.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepositoryImpl.java
@@ -1,0 +1,120 @@
+package com.househub.backend.domain.crawlingProperty.repository;
+
+import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyResDto;
+import com.househub.backend.domain.crawlingProperty.entity.*;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import com.querydsl.core.Tuple;
+
+@Repository
+@RequiredArgsConstructor
+public class CrawlingPropertyRepositoryImpl implements CrawlingPropertyRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<CrawlingProperty> findByAnyMatchingTags(List<String> propertyIds, List<Long> tagIds, Pageable pageable) {
+        QCrawlingProperty cp = QCrawlingProperty.crawlingProperty;
+        QCrawlingPropertyTagMap cptm = QCrawlingPropertyTagMap.crawlingPropertyTagMap;
+        QTag tag = QTag.tag;
+
+        // content 쿼리
+        List<Tuple> tupleContent = queryFactory
+                .select(cp, cptm.count().as("matchingTagCount"))
+                .from(cp)
+                .join(cp.crawlingPropertyTagMaps, cptm)
+                .join(cptm.tag, tag)
+                .where(
+                        tag.tagId.in(tagIds),
+                        cp.crawlingPropertiesId.in(propertyIds)
+                )
+                .groupBy(cp.crawlingPropertiesId)
+                .orderBy(cptm.count().desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 매물만 추출
+        List<CrawlingProperty> content = tupleContent.stream()
+                .map(tuple -> tuple.get(cp))   // 여기 cp는 QCrawlingProperty 타입 그대로
+                .collect(Collectors.toList());
+
+        // total 쿼리
+        Long total = queryFactory
+                .select(cp.crawlingPropertiesId.countDistinct())
+                .from(cp)
+                .join(cp.crawlingPropertyTagMaps, cptm)
+                .where(
+                        cptm.tag.tagId.in(tagIds),
+                        cp.crawlingPropertiesId.in(propertyIds)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+
+//    public Page<CrawlingPropertyResDto> findByAnyMatchingTags2(List<String> propertyIds, List<Long> tagIds, Pageable pageable) {
+//        QCrawlingProperty cp = QCrawlingProperty.crawlingProperty;
+//        QCrawlingPropertyTagMap cptm = QCrawlingPropertyTagMap.crawlingPropertyTagMap;
+//        QTag tag = QTag.tag;
+//
+//        // 1. tuple 조회
+//        List<Tuple> tupleContent = queryFactory
+//                .select(cp, cptm.count())
+//                .from(cp)
+//                .join(cp.crawlingPropertyTagMaps, cptm)
+//                .join(cptm.tag, tag)
+//                .where(
+//                        tag.tagId.in(tagIds),
+//                        cp.crawlingPropertiesId.in(propertyIds)
+//                )
+//                .groupBy(cp.crawlingPropertiesId)
+//                .orderBy(cptm.count().desc())
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .fetch();
+//
+//        if (tupleContent.isEmpty()) {
+//            return Page.empty(pageable);
+//        }
+//
+//        // 2. CrawlingProperty 리스트 추출
+//        List<CrawlingProperty> crawlingProperties = tupleContent.stream()
+//                .map(tuple -> tuple.get(0, CrawlingProperty.class))
+//                .toList();
+//
+//        // 3. CrawlingProperty ID 리스트 추출
+//        List<String> crawlingPropertiesIds = crawlingProperties.stream()
+//                .map(CrawlingProperty::getCrawlingPropertiesId)
+//                .toList();
+//
+//        // 4. 매물 ID로 태그 매핑 조회
+//        List<CrawlingPropertyTagMap> tagMappings = queryFactory
+//                .selectFrom(cptm)
+//                .where(cptm.crawlingProperty.crawlingPropertiesId.in(crawlingPropertiesIds))
+//                .fetch();
+//
+//        // 5. 매물별로 태그 리스트 묶기
+//        Map<String, List<Tag>> propertyTagsMap = tagMappings.stream()
+//                .collect(Collectors.groupingBy(
+//                        mapping -> mapping.getCrawlingProperty().getCrawlingPropertiesId(), // 여기 이름 충돌 수정
+//                        Collectors.mapping(CrawlingPropertyTagMap::getTag, Collectors.toList())
+//                ));
+//
+//        // 6. DTO로 변환
+//        List<CrawlingPropertyResDto> dtoList = crawlingProperties.stream()
+//                .map(crawlingProperty -> CrawlingPropertyResDto.fromEntity(crawlingProperty, propertyTagsMap))
+//                .toList();
+//
+//        // 7. Page로 변환
+//        return new PageImpl<>(dtoList, pageable, propertyIds.size());
+//    }
+}

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/repository/TagRepository.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.househub.backend.domain.crawlingProperty.repository;
+
+import com.househub.backend.domain.crawlingProperty.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/service/CrawlingPropertyService.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/service/CrawlingPropertyService.java
@@ -1,7 +1,9 @@
 package com.househub.backend.domain.crawlingProperty.service;
 
+import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyListResDto;
 import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyReqDto;
 import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyResDto;
+import com.househub.backend.domain.crawlingProperty.entity.CrawlingProperty;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -10,5 +12,9 @@ public interface CrawlingPropertyService {
 
     CrawlingPropertyResDto findOne(String id);
 
-    List<CrawlingPropertyResDto> findAll(CrawlingPropertyReqDto crawlingPropertyReqDto, Pageable pageable);
+    CrawlingPropertyListResDto findAll(CrawlingPropertyReqDto crawlingPropertyReqDto, Pageable pageable);
+
+    CrawlingPropertyListResDto findPropertiesByTags(List<Long> tagIds, CrawlingPropertyReqDto crawlingPropertyReqDto, Pageable pageable);
+
+//    CrawlingPropertyListResDto findPropertiesByTags2(List<Long> tagIds, CrawlingPropertyReqDto crawlingPropertyReqDto, Pageable pageable);
 }

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/service/CrawlingTagService.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/service/CrawlingTagService.java
@@ -1,0 +1,10 @@
+package com.househub.backend.domain.crawlingProperty.service;
+
+import com.househub.backend.domain.crawlingProperty.dto.CrawlingTagResDto;
+
+import java.util.List;
+
+public interface CrawlingTagService {
+
+    List<CrawlingTagResDto> findAll();
+}

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/service/impl/CrawlingPropertyServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/service/impl/CrawlingPropertyServiceImpl.java
@@ -1,19 +1,23 @@
 package com.househub.backend.domain.crawlingProperty.service.impl;
 
 import com.househub.backend.common.exception.ResourceNotFoundException;
+import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyListResDto;
 import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyReqDto;
 import com.househub.backend.domain.crawlingProperty.dto.CrawlingPropertyResDto;
 import com.househub.backend.domain.crawlingProperty.entity.CrawlingProperty;
+import com.househub.backend.domain.crawlingProperty.entity.CrawlingPropertyTagMap;
 import com.househub.backend.domain.crawlingProperty.repository.CrawlingPropertyRepository;
 import com.househub.backend.domain.crawlingProperty.service.CrawlingPropertyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -24,15 +28,22 @@ public class CrawlingPropertyServiceImpl implements CrawlingPropertyService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<CrawlingPropertyResDto> findAll(
+    public CrawlingPropertyListResDto findAll(
         CrawlingPropertyReqDto crawlingPropertyReqDto,
         Pageable pageable
     ) {
         Page<CrawlingProperty> crawlingPropertyList = crawlingPropertyRepository.findByDto(
                 crawlingPropertyReqDto.getTransactionType(),
+                crawlingPropertyReqDto.getPropertyType(),
                 crawlingPropertyReqDto.getProvince(),
                 crawlingPropertyReqDto.getCity(),
                 crawlingPropertyReqDto.getDong(),
+                correctMinValue(crawlingPropertyReqDto.getMinSalePrice()), // 최소값 0 적용
+                crawlingPropertyReqDto.getMaxSalePrice(),
+                correctMinValue(crawlingPropertyReqDto.getMinDeposit()),
+                crawlingPropertyReqDto.getMaxDeposit(),
+                correctMinValue(crawlingPropertyReqDto.getMinMonthlyRent()),
+                crawlingPropertyReqDto.getMaxMonthlyRent(),
                 pageable
         );
 
@@ -40,9 +51,104 @@ public class CrawlingPropertyServiceImpl implements CrawlingPropertyService {
             throw new ResourceNotFoundException("크롤링 매물 목록이 존재하지 않습니다:", "CRAWLING_PROPERTIES_NOT_FOUND");
         }
 
-        return crawlingPropertyList.stream()
-                .map(CrawlingPropertyResDto::fromEntity)
+        Page<CrawlingPropertyResDto> response = crawlingPropertyList.map(CrawlingPropertyResDto::fromEntity);
+
+        return CrawlingPropertyListResDto.fromPage(response);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public CrawlingPropertyListResDto findPropertiesByTags(
+            List<Long> tagIds,
+            CrawlingPropertyReqDto crawlingPropertyReqDto,
+            Pageable pageable
+    ) {
+        // 1차 필터
+        Page<CrawlingProperty> crawlingPropertyList = crawlingPropertyRepository.findByDto(
+                crawlingPropertyReqDto.getTransactionType(),
+                crawlingPropertyReqDto.getPropertyType(),
+                crawlingPropertyReqDto.getProvince(),
+                crawlingPropertyReqDto.getCity(),
+                crawlingPropertyReqDto.getDong(),
+                correctMinValue(crawlingPropertyReqDto.getMinSalePrice()), // 최소값 0 적용
+                crawlingPropertyReqDto.getMaxSalePrice(),
+                correctMinValue(crawlingPropertyReqDto.getMinDeposit()),
+                crawlingPropertyReqDto.getMaxDeposit(),
+                correctMinValue(crawlingPropertyReqDto.getMinMonthlyRent()),
+                crawlingPropertyReqDto.getMaxMonthlyRent(),
+                pageable
+        );
+        if (crawlingPropertyList.isEmpty()) {
+            throw new ResourceNotFoundException("크롤링 매물 목록이 존재하지 않습니다:", "CRAWLING_PROPERTIES_NOT_FOUND");
+        }
+
+        // crawlingPropertiesId 리스트만 추출
+        List<CrawlingProperty> searchedCrawlingProperty = crawlingPropertyList.getContent().stream()
+                .filter(cp -> {
+                    List<Long> tagMapList = cp.getCrawlingPropertyTagMaps().stream()
+                            .map(cptm -> cptm.getTag().getTagId()) // 매핑을 tagId로 바꿔
+                            .toList();
+
+                    return tagIds.stream().anyMatch(tagMapList::contains);
+                })
                 .toList();
+
+        // Page 객체로 변환
+        Page<CrawlingProperty> searchedCrawlingPropertyPage = new PageImpl<>(
+                searchedCrawlingProperty,
+                crawlingPropertyList.getPageable(), // 기존 pageable 그대로 재사용
+                crawlingPropertyList.getTotalElements() // 전체 데이터 개수 그대로
+        );
+
+        Page<CrawlingPropertyResDto> response = searchedCrawlingPropertyPage.map(CrawlingPropertyResDto::fromEntity);
+
+        return CrawlingPropertyListResDto.fromPage(response);
+    }
+
+
+//    @Transactional(readOnly = true)
+//    @Override
+//    public CrawlingPropertyListResDto findPropertiesByTags2(
+//            List<Long> tagIds,
+//            CrawlingPropertyReqDto crawlingPropertyReqDto,
+//            Pageable pageable
+//    ) {
+//        // 1차 필터
+//        List<CrawlingProperty> crawlingPropertyList = crawlingPropertyRepository.findByDto2(
+//                crawlingPropertyReqDto.getTransactionType(),
+//                crawlingPropertyReqDto.getPropertyType(),
+//                crawlingPropertyReqDto.getProvince(),
+//                crawlingPropertyReqDto.getCity(),
+//                crawlingPropertyReqDto.getDong(),
+//                correctMinValue(crawlingPropertyReqDto.getMinSalePrice()), // 최소값 0 적용
+//                crawlingPropertyReqDto.getMaxSalePrice(),
+//                correctMinValue(crawlingPropertyReqDto.getMinDeposit()),
+//                crawlingPropertyReqDto.getMaxDeposit(),
+//                correctMinValue(crawlingPropertyReqDto.getMinMonthlyRent()),
+//                crawlingPropertyReqDto.getMaxMonthlyRent()
+//        );
+//
+//        if (crawlingPropertyList.isEmpty()) {
+//            throw new ResourceNotFoundException("크롤링 매물 목록이 존재하지 않습니다:", "CRAWLING_PROPERTIES_NOT_FOUND");
+//        }
+//
+//        // id 리스트 변환
+//        List<String> propertyIds = crawlingPropertyList.stream()
+//                .map(CrawlingProperty::getCrawlingPropertiesId)
+//                .toList();
+//
+//        // 2차 태그 매칭 + 페이징 정렬
+//        Page<CrawlingPropertyResDto> response = crawlingPropertyRepository.findByAnyMatchingTags2(propertyIds, tagIds, pageable);
+//
+//        return CrawlingPropertyListResDto.fromPage(response);
+//    }
+
+
+
+    // 최소 가격을 0으로 설정
+    private Float correctMinValue(Float value) {
+        if (value == null) return null;
+        return Math.max(0.0f, value);
     }
 
     public CrawlingPropertyResDto findOne(String id) {

--- a/src/main/java/com/househub/backend/domain/crawlingProperty/service/impl/CrawlingTagServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/service/impl/CrawlingTagServiceImpl.java
@@ -1,0 +1,29 @@
+package com.househub.backend.domain.crawlingProperty.service.impl;
+
+import com.househub.backend.domain.crawlingProperty.dto.CrawlingTagResDto;
+import com.househub.backend.domain.crawlingProperty.entity.Tag;
+import com.househub.backend.domain.crawlingProperty.repository.TagRepository;
+import com.househub.backend.domain.crawlingProperty.service.CrawlingTagService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CrawlingTagServiceImpl implements CrawlingTagService {
+    private final TagRepository tagRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<CrawlingTagResDto> findAll() {
+        List<Tag> tags = tagRepository.findAll();
+
+        return tags.stream()
+                .map(CrawlingTagResDto::fromEntity)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 크롤링 매물 검색 기능에 태그 검색 기능을 추가
- 매물 유형, 가격 등 기존 검색 조건에 태그 id 리스트를 추가함
- 프론트에서 조건에 맞는 태그 버튼을 클릭하면 태그 id 리스트를 반환함
- 해당 id 리스트를 받아서 api에서 검색에 활용

## ✏️ 변경 사항
- 변경된 내용을 간략하게 나열해주세요.

## 📸 스크린샷 (선택사항)
- UI 변경이나 기능 추가 시 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #166 
