### PR TITLE
youngseok, fix: 고객 복구 기능 구현+ 삭제된 고객만 반환하도록 수정 + dto 정리 #165

### DIFF
--- a/src/main/java/com/househub/backend/domain/contract/dto/FindContractResDto.java
+++ b/src/main/java/com/househub/backend/domain/contract/dto/FindContractResDto.java
@@ -6,7 +6,7 @@ import com.househub.backend.domain.agent.dto.GetMyInfoResDto;
 import com.househub.backend.domain.contract.entity.Contract;
 import com.househub.backend.domain.contract.enums.ContractStatus;
 import com.househub.backend.domain.contract.enums.ContractType;
-import com.househub.backend.domain.customer.dto.CreateCustomerResDto;
+import com.househub.backend.domain.customer.dto.CustomerResDto;
 import com.househub.backend.domain.property.dto.FindPropertyResDto;
 
 import lombok.Builder;
@@ -18,7 +18,7 @@ public class FindContractResDto {
     private Long id; // 계약 ID
     private GetMyInfoResDto agent;
     private FindPropertyResDto property; // 매물
-    private CreateCustomerResDto customer; // 고객
+    private CustomerResDto customer; // 고객
     private ContractType contractType; // 거래 유형 (매매, 전세, 월세)
     private Long salePrice; // 매매가
     private Long jeonsePrice; // 전세가
@@ -37,7 +37,7 @@ public class FindContractResDto {
                 .agent(GetMyInfoResDto.from(contract.getAgent()))
                 .property(FindPropertyResDto.toDto(contract.getProperty()))
                 .customer(contract.getCustomer() != null ?
-                        CreateCustomerResDto.fromEntity(contract.getCustomer()) : null)
+                        CustomerResDto.fromEntity(contract.getCustomer()) : null)
                 .contractType(contract.getContractType())
                 .salePrice(contract.getSalePrice())
                 .jeonsePrice(contract.getJeonsePrice())

--- a/src/main/java/com/househub/backend/domain/customer/controller/CustomerController.java
+++ b/src/main/java/com/househub/backend/domain/customer/controller/CustomerController.java
@@ -27,13 +27,12 @@ import com.househub.backend.domain.consultation.dto.ConsultationListResDto;
 import com.househub.backend.domain.consultation.service.ConsultationService;
 import com.househub.backend.domain.contract.dto.ContractListResDto;
 import com.househub.backend.domain.contract.service.ContractService;
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
-import com.househub.backend.domain.customer.dto.CreateCustomerResDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerResDto;
 import com.househub.backend.domain.customer.dto.CustomerListResDto;
 import com.househub.backend.domain.customer.service.CustomerService;
 import com.househub.backend.domain.inquiry.dto.InquiryListResDto;
 import com.househub.backend.domain.inquiry.service.InquiryService;
-import com.househub.backend.domain.property.dto.PropertyListResDto;
 import com.househub.backend.domain.property.entity.Property;
 import com.househub.backend.domain.property.service.PropertyService;
 
@@ -57,10 +56,10 @@ public class CustomerController {
 		description = "새로운 고객을 등록합니다. 이메일이 중복되는 경우 등록이 불가합니다. 로그인한 공인중개사 정보도 함께 저장됩니다."
 	)
 	@PostMapping("")
-	public ResponseEntity<SuccessResponse<CreateCustomerResDto>> createCustomer(
-		@Valid @RequestBody CreateCustomerReqDto request) {
+	public ResponseEntity<SuccessResponse<CustomerResDto>> createCustomer(
+		@Valid @RequestBody CustomerReqDto request) {
 		AgentResDto agentDto = SecurityUtil.getAuthenticatedAgent();
-		CreateCustomerResDto response = customerService.create(request,agentDto);
+		CustomerResDto response = customerService.create(request,agentDto);
 		return ResponseEntity.ok(SuccessResponse.success("고객 등록이 완료되었습니다.", "CUSTOMER_REGISTER_SUCCESS", response));
 	}
 
@@ -87,9 +86,9 @@ public class CustomerController {
 		description = "특정 고객의 상세 정보 조회합니다. 삭제된 고객이거나 본인이 등록하지 않은 고객은 조회할 수 없습니다."
 	)
 	@GetMapping("/{id}")
-	public ResponseEntity<SuccessResponse<CreateCustomerResDto>> findOneCustomer(@PathVariable Long id) {
+	public ResponseEntity<SuccessResponse<CustomerResDto>> findOneCustomer(@PathVariable Long id) {
 		AgentResDto agentDto = SecurityUtil.getAuthenticatedAgent();
-		CreateCustomerResDto response = customerService.findDetailsById(id, agentDto);
+		CustomerResDto response = customerService.findDetailsById(id, agentDto);
 		return ResponseEntity.ok(SuccessResponse.success("고객 상세 조회가 완료되었습니다.", "FIND_CUSTOMER_SUCCESS", response));
 	}
 
@@ -152,10 +151,10 @@ public class CustomerController {
 		description = "특정 고객의 정보를 수정합니다. 이메일이 중복되거나 본인이 담당하지 않은 고객은 수정할 수 없습니다."
 	)
 	@PutMapping("/{id}")
-	public ResponseEntity<SuccessResponse<CreateCustomerResDto>> updateCustomer(@PathVariable Long id,
-		@Valid @RequestBody CreateCustomerReqDto request) {
+	public ResponseEntity<SuccessResponse<CustomerResDto>> updateCustomer(@PathVariable Long id,
+		@Valid @RequestBody CustomerReqDto request) {
 		AgentResDto agentDto = SecurityUtil.getAuthenticatedAgent();
-		CreateCustomerResDto response = customerService.update(id, request, agentDto);
+		CustomerResDto response = customerService.update(id, request, agentDto);
 
         return ResponseEntity.ok(SuccessResponse.success("고객 정보 수정이 완료되었습니다.", "UPDATE_CUSTOMER_SUCCESS", response));
     }
@@ -166,9 +165,9 @@ public class CustomerController {
 		description = "특정 고객을 삭제합니다. 이미 삭제된 고객은 삭제할 수 없습니다."
 	)
 	@DeleteMapping("/{id}")
-	public ResponseEntity<SuccessResponse<CreateCustomerResDto>> deleteCustomer(@PathVariable Long id) {
+	public ResponseEntity<SuccessResponse<CustomerResDto>> deleteCustomer(@PathVariable Long id) {
 		AgentResDto agentDto = SecurityUtil.getAuthenticatedAgent();
-		CreateCustomerResDto response = customerService.delete(id,agentDto);
+		CustomerResDto response = customerService.delete(id,agentDto);
 
         return ResponseEntity.ok(SuccessResponse.success("해당 고객의 삭제가 완료되었습니다.", "DELETE_CUSTOMER_SUCCESS", response));
     }
@@ -179,9 +178,9 @@ public class CustomerController {
 		description = "특정 고객을 복구합니다."
 	)
 	@PutMapping("/restore/{id}")
-	public ResponseEntity<SuccessResponse<CreateCustomerResDto>> restoreCustomer(@PathVariable Long id) {
+	public ResponseEntity<SuccessResponse<CustomerResDto>> restoreCustomer(@PathVariable Long id) {
 		AgentResDto agentDto = SecurityUtil.getAuthenticatedAgent();
-		CreateCustomerResDto response = customerService.restore(id,agentDto);
+		CustomerResDto response = customerService.restore(id,agentDto);
 
 		return ResponseEntity.ok(SuccessResponse.success("해당 고객의 복구가 완료되었습니다.", "RESTORE_CUSTOMER_SUCCESS",response));
 	}
@@ -191,13 +190,13 @@ public class CustomerController {
 		description = "엑셀 파일을 업로드하여 여러 고객 정보를 한 번에 등록합니다."
 	)
 	@PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<SuccessResponse<List<CreateCustomerResDto>>> createCustomersByExcel(
+	public ResponseEntity<SuccessResponse<List<CustomerResDto>>> createCustomersByExcel(
 		@RequestParam("file") MultipartFile file) {
 		AgentResDto agentDto = SecurityUtil.getAuthenticatedAgent();
 		if (file.isEmpty()) {
 			throw new IllegalArgumentException("업로드할 파일이 없습니다.");
 		}
-		List<CreateCustomerResDto> response = customerService.createAllByExcel(file,agentDto);
+		List<CustomerResDto> response = customerService.createAllByExcel(file,agentDto);
 		return ResponseEntity.ok(SuccessResponse.success("고객 정보 등록 완료", "CUSTOMER_REGISTER_SUCCESS", response));
 	}
 

--- a/src/main/java/com/househub/backend/domain/customer/dto/CustomerListResDto.java
+++ b/src/main/java/com/househub/backend/domain/customer/dto/CustomerListResDto.java
@@ -12,10 +12,10 @@ import lombok.Getter;
 @Getter
 @Builder
 public class CustomerListResDto {
-	private List<CreateCustomerResDto> content;
+	private List<CustomerResDto> content;
 	private PaginationDto pagination;
 
-	public static CustomerListResDto fromPage(Page<CreateCustomerResDto> page) {
+	public static CustomerListResDto fromPage(Page<CustomerResDto> page) {
 		return CustomerListResDto.builder()
 			.content(page.getContent())
 			.pagination(PaginationDto.fromPage(page))

--- a/src/main/java/com/househub/backend/domain/customer/dto/CustomerReqDto.java
+++ b/src/main/java/com/househub/backend/domain/customer/dto/CustomerReqDto.java
@@ -9,7 +9,6 @@ import com.househub.backend.domain.customer.enums.CustomerStatus;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,7 +20,7 @@ import java.time.LocalDate;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CreateCustomerReqDto {
+public class CustomerReqDto {
 
     private String name;
 

--- a/src/main/java/com/househub/backend/domain/customer/dto/CustomerResDto.java
+++ b/src/main/java/com/househub/backend/domain/customer/dto/CustomerResDto.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CreateCustomerResDto {
+public class CustomerResDto {
 	private Long id;
 	private String name;
 	private LocalDate birthDate;
@@ -27,8 +27,18 @@ public class CreateCustomerResDto {
 	private LocalDateTime updatedAt;
 	private LocalDateTime deletedAt;
 
-	public static CreateCustomerResDto fromEntity(Customer customer) {
-		return CreateCustomerResDto.builder()
+	public static CustomerResDto fromEntity(Customer customer) {
+		if (customer.getDeletedAt() != null) {
+			return CustomerResDto.builder()
+				.id(customer.getId())
+				.name("삭제된 고객")
+				.contact(customer.getContact())
+				.createdAt(customer.getCreatedAt())
+				.updatedAt(customer.getUpdatedAt())
+				.deletedAt(customer.getDeletedAt())
+				.build();
+		}
+		return CustomerResDto.builder()
 			.id(customer.getId())
 			.name(customer.getName())
 			.birthDate(customer.getBirthDate())
@@ -41,4 +51,5 @@ public class CreateCustomerResDto {
 			.deletedAt(customer.getDeletedAt())
 			.build();
 	}
+
 }

--- a/src/main/java/com/househub/backend/domain/customer/entity/Customer.java
+++ b/src/main/java/com/househub/backend/domain/customer/entity/Customer.java
@@ -4,14 +4,13 @@ import java.time.LocalDateTime;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import com.househub.backend.common.enums.Gender;
 import com.househub.backend.common.validation.ValidBirthDate;
 import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.consultation.entity.Consultation;
 import com.househub.backend.domain.contract.entity.Contract;
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
 import com.househub.backend.domain.customer.enums.CustomerStatus;
 
 import jakarta.persistence.Column;
@@ -101,7 +100,7 @@ public class Customer {
 		updatedAt = LocalDateTime.now();
 	}
 
-	public void update(CreateCustomerReqDto reqDto) {
+	public void update(CustomerReqDto reqDto) {
 		this.name = reqDto.getName();
 		this.email = reqDto.getEmail();
 		if (reqDto.getContact() != null && !reqDto.getContact().isEmpty()) {

--- a/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepositoryCustom.java
+++ b/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepositoryCustom.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import com.househub.backend.domain.customer.entity.Customer;
 
 public interface CustomerRepositoryCustom {
-	Page<Customer> findAllByAgentIdAndFiltersAndDeletedAtIsNull(
+	Page<Customer> findAllByAgentIdAndFiltersAndDeletedOnly(
 		Long agentId,
 		String name,
 		String contact,

--- a/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepositoryCustomImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/repository/CustomerRepositoryCustomImpl.java
@@ -23,7 +23,7 @@ public class CustomerRepositoryCustomImpl implements CustomerRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Page<Customer> findAllByAgentIdAndFiltersAndDeletedAtIsNull(Long agentId, String name, String contact,
+	public Page<Customer> findAllByAgentIdAndFiltersAndDeletedOnly(Long agentId, String name, String contact,
 		String email, boolean includeDeleted, Pageable pageable) {
 
 		QCustomer customer = QCustomer.customer;
@@ -31,7 +31,9 @@ public class CustomerRepositoryCustomImpl implements CustomerRepositoryCustom {
 		BooleanBuilder predicate = new BooleanBuilder();
 		predicate.and(customer.agent.id.eq(agentId));
 
-		if (!includeDeleted) {
+		if (includeDeleted) {
+			predicate.and(customer.deletedAt.isNotNull());
+		} else {
 			predicate.and(customer.deletedAt.isNull());
 		}
 
@@ -64,7 +66,6 @@ public class CustomerRepositoryCustomImpl implements CustomerRepositoryCustom {
 
 	}
 
-	// ✅ 반환 타입 Predicate로 변경
 	private Predicate anyFilter(
 		String name, String contact, String email, QCustomer customer
 	) {
@@ -86,7 +87,6 @@ public class CustomerRepositoryCustomImpl implements CustomerRepositoryCustom {
 			builder.or(customer.email.contains(email));
 		}
 
-		// ✅ 캐스팅 제거
 		return builder.hasValue() ? builder.getValue() : null;
 	}
 

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerExecutor.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerExecutor.java
@@ -1,16 +1,15 @@
 package com.househub.backend.domain.customer.service;
 
 import com.househub.backend.domain.agent.entity.Agent;
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
 import com.househub.backend.domain.customer.entity.Customer;
-import com.househub.backend.domain.sms.entity.Sms;
 
 public interface CustomerExecutor {
-	Customer validateAndUpdate(Long id, CreateCustomerReqDto request, Agent agent);
+	Customer validateAndUpdate(Long id, CustomerReqDto request, Agent agent);
 
 	Customer validateAndDelete(Long id, Agent agent);
 
-	Customer findOrCreateCustomer(CreateCustomerReqDto request, Agent agent);
+	Customer findOrCreateCustomer(CustomerReqDto request, Agent agent);
 
 	Customer validateAndRestore(Long id, Agent agent);
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerService.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerService.java
@@ -6,8 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.househub.backend.domain.agent.dto.AgentResDto;
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
-import com.househub.backend.domain.customer.dto.CreateCustomerResDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerResDto;
 import com.househub.backend.domain.customer.dto.CustomerListResDto;
 
 public interface CustomerService {
@@ -15,17 +15,17 @@ public interface CustomerService {
     // Criteria : 조회 요청
     // Info : 리턴
 
-    CreateCustomerResDto create(CreateCustomerReqDto request, AgentResDto agentDto);
+    CustomerResDto create(CustomerReqDto request, AgentResDto agentDto);
 
-    List<CreateCustomerResDto> createAllByExcel(MultipartFile file, AgentResDto agentDto);
+    List<CustomerResDto> createAllByExcel(MultipartFile file, AgentResDto agentDto);
 
     CustomerListResDto findAll(String keyword, AgentResDto agentDto, Pageable pageable, boolean includeDeleted);
 
-    CreateCustomerResDto findDetailsById(Long id, AgentResDto agentDto);
+    CustomerResDto findDetailsById(Long id, AgentResDto agentDto);
 
-    CreateCustomerResDto update(Long id, CreateCustomerReqDto request, AgentResDto agentDto);
+    CustomerResDto update(Long id, CustomerReqDto request, AgentResDto agentDto);
 
-    CreateCustomerResDto delete(Long id, AgentResDto agentDto);
+    CustomerResDto delete(Long id, AgentResDto agentDto);
 
-    CreateCustomerResDto restore(Long id, AgentResDto agentDto);
+    CustomerResDto restore(Long id, AgentResDto agentDto);
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/CustomerStore.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/CustomerStore.java
@@ -2,7 +2,7 @@ package com.househub.backend.domain.customer.service;
 
 import java.util.List;
 
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
 import com.househub.backend.domain.customer.entity.Customer;
 
 public interface CustomerStore {
@@ -10,7 +10,7 @@ public interface CustomerStore {
 
 	List<Customer> createAll(List<Customer> customers);
 
-	Customer update(Customer customer, CreateCustomerReqDto request);
+	Customer update(Customer customer, CustomerReqDto request);
 
 	Customer delete(Customer customer);
 

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerExecutorImpl.java
@@ -4,12 +4,11 @@ import org.springframework.stereotype.Component;
 
 import com.househub.backend.domain.agent.entity.Agent;
 import com.househub.backend.domain.consultation.service.ConsultationService;
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
 import com.househub.backend.domain.customer.entity.Customer;
 import com.househub.backend.domain.customer.service.CustomerExecutor;
 import com.househub.backend.domain.customer.service.CustomerReader;
 import com.househub.backend.domain.customer.service.CustomerStore;
-import com.househub.backend.domain.sms.entity.Sms;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +22,7 @@ public class CustomerExecutorImpl implements CustomerExecutor {
 
 	@Transactional
 	@Override
-	public Customer findOrCreateCustomer(CreateCustomerReqDto request, Agent agent) {
+	public Customer findOrCreateCustomer(CustomerReqDto request, Agent agent) {
 		// 전화번호로 고객 조회해서 존재하지 않으면 고객 생성
 		return customerReader.findByContactAndAgentId(request.getContact(), agent.getId())
 			.orElseGet(() -> customerStore.create(
@@ -38,7 +37,7 @@ public class CustomerExecutorImpl implements CustomerExecutor {
 	}
 
 	@Override
-	public Customer validateAndUpdate(Long id, CreateCustomerReqDto request, Agent agent) {
+	public Customer validateAndUpdate(Long id, CustomerReqDto request, Agent agent) {
 		Customer customer = customerReader.findByIdOrThrow(id, agent.getId());
 		if (!customer.getContact().equals(request.getContact())) {
 			customerReader.checkDuplicatedByContact(request.getContact(), agent.getId());

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerReaderImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerReaderImpl.java
@@ -57,7 +57,7 @@ public class CustomerReaderImpl implements CustomerReader {
 
 	@Override
 	public Page<Customer> findAllByKeyword(String keyword, Long agentId, Pageable pageable, boolean includeDeleted) {
-		return customerRepository.findAllByAgentIdAndFiltersAndDeletedAtIsNull(
+		return customerRepository.findAllByAgentIdAndFiltersAndDeletedOnly(
 			agentId,
 			keyword,
 			keyword,

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerServiceImpl.java
@@ -14,8 +14,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.househub.backend.common.exception.InvalidExcelValueException;
 import com.househub.backend.domain.agent.dto.AgentResDto;
 import com.househub.backend.domain.agent.entity.Agent;
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
-import com.househub.backend.domain.customer.dto.CreateCustomerResDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerResDto;
 import com.househub.backend.domain.customer.dto.CustomerListResDto;
 import com.househub.backend.domain.customer.entity.Customer;
 import com.househub.backend.domain.customer.service.CustomerExecutor;
@@ -37,18 +37,18 @@ public class CustomerServiceImpl implements CustomerService {
 	private final CustomerExcelProcessor excelProcessor;
 
 	@Transactional
-	public CreateCustomerResDto create(CreateCustomerReqDto request, AgentResDto agentDto) {
+	public CustomerResDto create(CustomerReqDto request, AgentResDto agentDto) {
 		Agent agent = agentDto.toEntity();
 		customerReader.checkDuplicatedByContact(request.getContact(), agent.getId());
 		Customer storedCustomer = customerStore.create(request.toEntity(agent));
-		return CreateCustomerResDto.fromEntity(storedCustomer);
+		return CustomerResDto.fromEntity(storedCustomer);
 	}
 
 	@Transactional
-	public List<CreateCustomerResDto> createAllByExcel(MultipartFile file, AgentResDto agentDto) {
+	public List<CustomerResDto> createAllByExcel(MultipartFile file, AgentResDto agentDto) {
 		Agent agent = agentDto.toEntity();
-		ExcelParserUtils.ExcelParseResult<CreateCustomerReqDto> result = excelProcessor.process(file);
-		List<CreateCustomerReqDto> filteredDtos = new ArrayList<>(result.successData());
+		ExcelParserUtils.ExcelParseResult<CustomerReqDto> result = excelProcessor.process(file);
+		List<CustomerReqDto> filteredDtos = new ArrayList<>(result.successData());
 
 		if (!result.errors().isEmpty()) {
 			throw new InvalidExcelValueException("입력값에 " + result.errors().size() + " 개의 오류가 존재합니다.", result.errors(),
@@ -62,20 +62,20 @@ public class CustomerServiceImpl implements CustomerService {
 			.map(dto -> dto.toEntity(agent))
 			.toList();
 
-		return customerStore.createAll(customers).stream().map(CreateCustomerResDto::fromEntity).toList();
+		return customerStore.createAll(customers).stream().map(CustomerResDto::fromEntity).toList();
 	}
 
-	private void checkExcelDuplicates(List<CreateCustomerReqDto> dtos) {
+	private void checkExcelDuplicates(List<CustomerReqDto> dtos) {
 		Set<String> contacts = new HashSet<>();
-		for (CreateCustomerReqDto dto : dtos) {
+		for (CustomerReqDto dto : dtos) {
 			if (!contacts.add(dto.getContact())) {
 				throw new InvalidExcelValueException("엑셀 내 중복 연락처가 존재합니다. " + dto.getContact(), "DUPLICATED_CONTACT");
 			}
 		}
 	}
 
-	private void checkDatabaseDuplicates(List<CreateCustomerReqDto> dtos, Long agentId) {
-		for (CreateCustomerReqDto dto : dtos) {
+	private void checkDatabaseDuplicates(List<CustomerReqDto> dtos, Long agentId) {
+		for (CustomerReqDto dto : dtos) {
 			customerReader.checkDuplicatedByContact(dto.getContact(), agentId);
 			customerReader.checkDuplicatedByEmail(dto.getEmail(), agentId);
 		}
@@ -84,34 +84,34 @@ public class CustomerServiceImpl implements CustomerService {
 	public CustomerListResDto findAll(String keyword, AgentResDto agentDto, Pageable pageable, boolean includeDeleted) {
 		Agent agent = agentDto.toEntity();
 		Page<Customer> customerPage = customerReader.findAllByKeyword(keyword, agent.getId(), pageable, includeDeleted);
-		Page<CreateCustomerResDto> response = customerPage.map(CreateCustomerResDto::fromEntity);
+		Page<CustomerResDto> response = customerPage.map(CustomerResDto::fromEntity);
 		return CustomerListResDto.fromPage(response);
 	}
 
-	public CreateCustomerResDto findDetailsById(Long id, AgentResDto agentDto) {
+	public CustomerResDto findDetailsById(Long id, AgentResDto agentDto) {
 		Agent agent = agentDto.toEntity();
 		Customer customer = customerReader.findByIdOrThrow(id, agent.getId());
-		return CreateCustomerResDto.fromEntity(customer);
+		return CustomerResDto.fromEntity(customer);
 	}
 
 	@Transactional
-	public CreateCustomerResDto update(Long id, CreateCustomerReqDto request, AgentResDto agentDto) {
+	public CustomerResDto update(Long id, CustomerReqDto request, AgentResDto agentDto) {
 		Agent agent = agentDto.toEntity();
 		Customer updatedCustomer = customerExecutor.validateAndUpdate(id, request, agent);
-		return CreateCustomerResDto.fromEntity(updatedCustomer);
+		return CustomerResDto.fromEntity(updatedCustomer);
 	}
 
 	@Transactional
-	public CreateCustomerResDto delete(Long id, AgentResDto agentDto) {
+	public CustomerResDto delete(Long id, AgentResDto agentDto) {
 		Agent agent = agentDto.toEntity();
 		Customer deletedCustomer = customerExecutor.validateAndDelete(id, agent);
-		return CreateCustomerResDto.fromEntity(deletedCustomer);
+		return CustomerResDto.fromEntity(deletedCustomer);
 	}
 
 	@Transactional
-	public CreateCustomerResDto restore(Long id, AgentResDto agentDto) {
+	public CustomerResDto restore(Long id, AgentResDto agentDto) {
 		Agent agent = agentDto.toEntity();
 		Customer restoredCustomer = customerExecutor.validateAndRestore(id,agent);
-		return CreateCustomerResDto.fromEntity(restoredCustomer);
+		return CustomerResDto.fromEntity(restoredCustomer);
 	}
 }

--- a/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerStoreImpl.java
+++ b/src/main/java/com/househub/backend/domain/customer/service/impl/CustomerStoreImpl.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
 import com.househub.backend.domain.customer.entity.Customer;
 import com.househub.backend.domain.customer.repository.CustomerRepository;
 import com.househub.backend.domain.customer.service.CustomerStore;
@@ -30,7 +30,7 @@ public class CustomerStoreImpl implements CustomerStore {
 	}
 
 	@Override
-	public Customer update(Customer customer, CreateCustomerReqDto request) {
+	public Customer update(Customer customer, CustomerReqDto request) {
 		customer.update(request);
 		return customerRepository.save(customer);
 	}

--- a/src/main/java/com/househub/backend/domain/customer/util/CustomerExcelProcessor.java
+++ b/src/main/java/com/househub/backend/domain/customer/util/CustomerExcelProcessor.java
@@ -14,7 +14,7 @@ import com.househub.backend.common.exception.InvalidExcelValueException;
 import com.househub.backend.common.exception.InvalidFormatException;
 import com.househub.backend.common.response.ErrorResponse.FieldError;
 import com.househub.backend.common.validation.CustomerExcelValidator;
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
 import com.househub.backend.domain.customer.enums.CustomerExcelColumn;
 
 import lombok.RequiredArgsConstructor;
@@ -51,7 +51,7 @@ public class CustomerExcelProcessor {
 		}
 	}
 
-	public ExcelParserUtils.ExcelParseResult<CreateCustomerReqDto> process(MultipartFile file) {
+	public ExcelParserUtils.ExcelParseResult<CustomerReqDto> process(MultipartFile file) {
 		String fileName = file.getOriginalFilename();
 		String extension = FilenameUtils.getExtension(fileName);
 
@@ -109,8 +109,8 @@ public class CustomerExcelProcessor {
 		return (value == null || value.trim().isEmpty()) ? null : value;
 	}
 
-	private CreateCustomerReqDto buildCustomerDto(Row row) {
-		return CreateCustomerReqDto.builder()
+	private CustomerReqDto buildCustomerDto(Row row) {
+		return CustomerReqDto.builder()
 			.name(getStringCell(row, CustomerExcelColumn.NAME))
 			.birthDate(getBirthDateCell(row, CustomerExcelColumn.BIRTH_DATE))
 			.contact(getStringCell(row, CustomerExcelColumn.CONTACT))

--- a/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryReqDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/dto/CreateInquiryReqDto.java
@@ -2,7 +2,7 @@ package com.househub.backend.domain.inquiry.dto;
 
 import java.util.List;
 
-import com.househub.backend.domain.customer.dto.CreateCustomerReqDto;
+import com.househub.backend.domain.customer.dto.CustomerReqDto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -35,8 +35,8 @@ public class CreateInquiryReqDto {
 		private Object answerText; // String, List<String> 모두 가능
 	}
 
-	public CreateCustomerReqDto toCustomerReqDto() {
-		return CreateCustomerReqDto.builder()
+	public CustomerReqDto toCustomerReqDto() {
+		return CustomerReqDto.builder()
 			.contact(this.phone)
 			.build();
 	}

--- a/src/main/java/com/househub/backend/domain/property/dto/FindPropertyDetailResDto.java
+++ b/src/main/java/com/househub/backend/domain/property/dto/FindPropertyDetailResDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.househub.backend.domain.contract.dto.FindContractResDto;
-import com.househub.backend.domain.customer.dto.CreateCustomerResDto;
+import com.househub.backend.domain.customer.dto.CustomerResDto;
 import com.househub.backend.domain.property.entity.Property;
 import com.househub.backend.domain.property.enums.PropertyDirection;
 import com.househub.backend.domain.property.enums.PropertyType;
@@ -18,7 +18,7 @@ public class FindPropertyDetailResDto {
 
     private Long id; // 매물 고유 식별자
     private PropertyType propertyType; // 매물 유형
-    private CreateCustomerResDto customer; // 의뢰인(임대인 또는 매도인)
+    private CustomerResDto customer; // 의뢰인(임대인 또는 매도인)
     private String memo; // 참고 설명
     private String detailAddress; // 상세 주소
     private String roadAddress; // 전체 도로명 주소
@@ -38,7 +38,7 @@ public class FindPropertyDetailResDto {
         return FindPropertyDetailResDto.builder()
                 .id(property.getId())
                 .propertyType(property.getPropertyType())
-                .customer(CreateCustomerResDto.fromEntity(property.getCustomer()))
+                .customer(CustomerResDto.fromEntity(property.getCustomer()))
                 .memo(property.getMemo())
                 .detailAddress(property.getDetailAddress())
                 .roadAddress(property.getRoadAddress())

--- a/src/main/java/com/househub/backend/domain/property/dto/FindPropertyResDto.java
+++ b/src/main/java/com/househub/backend/domain/property/dto/FindPropertyResDto.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.househub.backend.domain.contract.entity.Contract;
 import com.househub.backend.domain.contract.enums.ContractType;
-import com.househub.backend.domain.customer.dto.CreateCustomerResDto;
+import com.househub.backend.domain.customer.dto.CustomerResDto;
 import com.househub.backend.domain.property.entity.Property;
 import com.househub.backend.domain.property.enums.PropertyType;
 
@@ -16,7 +16,7 @@ import lombok.Getter;
 public class FindPropertyResDto {
 
 	private Long id; // 매물 고유 식별자
-	private CreateCustomerResDto customer;
+	private CustomerResDto customer;
 	private PropertyType propertyType; // 매물 유형
 	private String detailAddress; // 상세 주소
 	private String roadAddress; // 전체 도로명 주소
@@ -29,7 +29,7 @@ public class FindPropertyResDto {
 	public static FindPropertyResDto toDto(Property property) {
 		return FindPropertyResDto.builder()
 			.id(property.getId())
-			.customer(CreateCustomerResDto.fromEntity(property.getCustomer()))
+			.customer(CustomerResDto.fromEntity(property.getCustomer()))
 			.propertyType(property.getPropertyType())
 			.detailAddress(property.getDetailAddress())
 			.roadAddress(property.getRoadAddress())

--- a/src/test/java/com/househub/backend/domain/customer/service/CustomerReaderImplTest.java
+++ b/src/test/java/com/househub/backend/domain/customer/service/CustomerReaderImplTest.java
@@ -174,7 +174,7 @@ class CustomerReaderImplTest {
 			Page<Customer> mockPage = new PageImpl<>(Collections.singletonList(customer));
 
 			// ✅ includeDeleted 파라미터 추가
-			when(customerRepository.findAllByAgentIdAndFiltersAndDeletedAtIsNull(
+			when(customerRepository.findAllByAgentIdAndFiltersAndDeletedOnly(
 				agentId, keyword, keyword, keyword, includeDeleted, pageable))
 				.thenReturn(mockPage);
 
@@ -187,7 +187,7 @@ class CustomerReaderImplTest {
 
 			// verify (파라미터 개수 일치 확인)
 			verify(customerRepository, times(1))
-				.findAllByAgentIdAndFiltersAndDeletedAtIsNull(agentId, keyword, keyword, keyword, includeDeleted,
+				.findAllByAgentIdAndFiltersAndDeletedOnly(agentId, keyword, keyword, keyword, includeDeleted,
 					pageable);
 		}
 	}


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 고객(사용자) 관리 기능 개선을 위한 PR입니다.
- 고객 복구(restore) 기능을 신규 구현하고, 삭제된 고객만 반환하는 로직으로 수정하였으며, 관련 DTO 정리와 리팩토링을 진행했습니다.

## ✏️ 변경 사항
- 고객 복구(restore) 기능 구현
    - 삭제 처리된 고객을 복구할 수 있도록 관련 서비스 및 컨트롤러 메서드 추가
- 삭제된 고객만 반환하도록 서비스 및 레포지토리 쿼리 수정
    - soft delete 처리된 고객 목록만 필터링하여 반환
- 관련 DTO 클래스명 및 필드명 정리
    - `CreateCustomerReqDto`, `CreateCustomerResDto`를 각각 `CustomerReqDto`, `CustomerResDto`로 변경 및 통합
    - 불필요하거나 혼동되는 필드명·주석 정비
- 코드 리팩토링 및 중복 코드 제거
    - 서비스/컨트롤러/엔티티/레포지토리 관련 메서드 및 코드 블록 구조 개선

## 📸 스크린샷 (선택사항)
- UI 변경 사항 없음

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [x] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?  
  (API 문서 등 필요 시 추가 예정)

## 🔗 관련 이슈 (선택사항)
- 관련 이슈: #165
