### PR TITLE
seongeun, feat: 매물 등록 시, 계약 정보도 함께 등록하도록 수정 #182

### DIFF
--- a/src/main/java/com/househub/backend/domain/contract/dto/BasicContractDto.java
+++ b/src/main/java/com/househub/backend/domain/contract/dto/BasicContractDto.java
@@ -1,0 +1,51 @@
+package com.househub.backend.domain.contract.dto;
+
+import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.contract.entity.Contract;
+import com.househub.backend.domain.contract.enums.ContractStatus;
+import com.househub.backend.domain.contract.enums.ContractType;
+import com.househub.backend.domain.property.entity.Property;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class BasicContractDto {
+    @NotNull(message = "거래 유형은 필수입니다.")
+    private ContractType contractType; // 거래 유형 (매매, 전세, 월세)
+    @Positive(message = "매매가는 0보다 큰 값이어야 합니다.")
+    private Long salePrice; // 매매가 (매매 계약일 경우 필요)
+    @Positive(message = "전세가는 0보다 큰 값이어야 합니다.")
+    private Long jeonsePrice; // 전세가 (전세 계약일 경우 필요)
+    @Positive(message = "월세는 0보다 큰 값이어야 합니다.")
+    private Long monthlyRentFee; // 월세 금액 (월세 계약일 경우 필요)
+    @Positive(message = "보증금은 0보다 큰 값이어야 합니다.")
+    private Long monthlyRentDeposit; // 월세 보증금 (월세 계약일 경우 필요)
+
+    // 자동 실행
+    @AssertTrue(message = "거래 유형에 따라 적절한 가격 정보가 필요합니다.")
+    public boolean isValidContractType() {
+        if (contractType == ContractType.SALE) { // 매매
+            return salePrice != null && jeonsePrice == null && monthlyRentDeposit == null && monthlyRentFee == null;
+        } else if (contractType == ContractType.JEONSE) { // 전세
+            return salePrice == null && jeonsePrice != null && monthlyRentDeposit == null && monthlyRentFee == null;
+        } else if (contractType == ContractType.MONTHLY_RENT) { // 월세
+            return salePrice == null && jeonsePrice == null && monthlyRentDeposit != null && monthlyRentFee != null;
+        }
+        return false;
+    }
+
+    public Contract toEntity(Property property, Agent agent) {
+        return Contract.builder()
+                .property(property)
+                .agent(agent)
+                .status(ContractStatus.AVAILABLE)
+                .contractType(this.contractType)
+                .salePrice(this.salePrice)
+                .jeonsePrice(this.jeonsePrice)
+                .monthlyRentFee(this.monthlyRentFee)
+                .monthlyRentDeposit(this.monthlyRentDeposit)
+                .build();
+    }
+}

--- a/src/main/java/com/househub/backend/domain/contract/dto/CreateContractReqDto.java
+++ b/src/main/java/com/househub/backend/domain/contract/dto/CreateContractReqDto.java
@@ -24,7 +24,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateContractReqDto {
-//    @NotNull(message = "매물 id를 입력해 주세요.")
+    @NotNull(message = "매물 id를 입력해 주세요.")
     private Long propertyId; // 매물 ID
     private Long customerId; // 고객 ID
     @NotNull(message = "거래 유형은 필수입니다.")

--- a/src/main/java/com/househub/backend/domain/contract/dto/CreateContractReqDto.java
+++ b/src/main/java/com/househub/backend/domain/contract/dto/CreateContractReqDto.java
@@ -24,7 +24,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateContractReqDto {
-    @NotNull(message = "매물 id를 입력해 주세요.")
+//    @NotNull(message = "매물 id를 입력해 주세요.")
     private Long propertyId; // 매물 ID
     private Long customerId; // 고객 ID
     @NotNull(message = "거래 유형은 필수입니다.")

--- a/src/main/java/com/househub/backend/domain/property/dto/CreatePropertyReqDto.java
+++ b/src/main/java/com/househub/backend/domain/property/dto/CreatePropertyReqDto.java
@@ -1,7 +1,7 @@
 package com.househub.backend.domain.property.dto;
 
 import com.househub.backend.domain.agent.entity.Agent;
-import com.househub.backend.domain.contract.dto.CreateContractReqDto;
+import com.househub.backend.domain.contract.dto.BasicContractDto;
 import com.househub.backend.domain.customer.entity.Customer;
 import com.househub.backend.domain.property.entity.Property;
 import com.househub.backend.domain.property.enums.PropertyDirection;
@@ -12,6 +12,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Builder
 @Getter
@@ -37,7 +39,7 @@ public class CreatePropertyReqDto {
 	private Integer bathroomCnt; // 욕실 개수
 	private Integer roomCnt; // 방 개수
 	private Boolean active; // 매물이 계약 가능한지 여부
-	private CreateContractReqDto contract;
+	private List<BasicContractDto> contracts;
 
 	public Property toEntity(Customer customer, Agent agent) {
 		Property property = Property.builder()

--- a/src/main/java/com/househub/backend/domain/property/dto/CreatePropertyReqDto.java
+++ b/src/main/java/com/househub/backend/domain/property/dto/CreatePropertyReqDto.java
@@ -1,6 +1,7 @@
 package com.househub.backend.domain.property.dto;
 
 import com.househub.backend.domain.agent.entity.Agent;
+import com.househub.backend.domain.contract.dto.CreateContractReqDto;
 import com.househub.backend.domain.customer.entity.Customer;
 import com.househub.backend.domain.property.entity.Property;
 import com.househub.backend.domain.property.enums.PropertyDirection;
@@ -36,6 +37,7 @@ public class CreatePropertyReqDto {
 	private Integer bathroomCnt; // 욕실 개수
 	private Integer roomCnt; // 방 개수
 	private Boolean active; // 매물이 계약 가능한지 여부
+	private CreateContractReqDto contract;
 
 	public Property toEntity(Customer customer, Agent agent) {
 		Property property = Property.builder()

--- a/src/main/java/com/househub/backend/domain/property/service/impl/PropertyServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/property/service/impl/PropertyServiceImpl.java
@@ -2,7 +2,7 @@ package com.househub.backend.domain.property.service.impl;
 
 import java.util.List;
 
-import com.househub.backend.domain.contract.dto.CreateContractReqDto;
+import com.househub.backend.domain.contract.dto.BasicContractDto;
 import com.househub.backend.domain.contract.service.ContractStore;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -58,10 +58,9 @@ public class PropertyServiceImpl implements PropertyService {
 		// db에 저장
 		propertyStore.create(property);
 		// 계약 등록 - '계약 가능' 상태로 등록 (계약자 없음)
-		if(dto.getContract() != null) {
-			CreateContractReqDto contractReqDto = dto.getContract();
-			contractReqDto.setPropertyId(property.getId());
-			contractStore.create(contractReqDto.toEntity(property, null, agent));
+		if(dto.getContracts() != null) {
+			List<BasicContractDto> contractReqDto = dto.getContracts();
+			contractReqDto.forEach(c -> contractStore.create(c.toEntity(property, agent)));
 		}
 		// 응답 객체 리턴
 		return new CreatePropertyResDto(property.getId());

--- a/src/main/java/com/househub/backend/domain/property/service/impl/PropertyServiceImpl.java
+++ b/src/main/java/com/househub/backend/domain/property/service/impl/PropertyServiceImpl.java
@@ -2,6 +2,8 @@ package com.househub.backend.domain.property.service.impl;
 
 import java.util.List;
 
+import com.househub.backend.domain.contract.dto.CreateContractReqDto;
+import com.househub.backend.domain.contract.service.ContractStore;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PropertyServiceImpl implements PropertyService {
 
+	private final ContractStore contractStore;
 	private final CustomerReader customerReader;
 	private final PropertyStore propertyStore;
 	private final PropertyReader propertyReader;
@@ -54,6 +57,12 @@ public class PropertyServiceImpl implements PropertyService {
 		Property property = dto.toEntity(customer, agent);
 		// db에 저장
 		propertyStore.create(property);
+		// 계약 등록 - '계약 가능' 상태로 등록 (계약자 없음)
+		if(dto.getContract() != null) {
+			CreateContractReqDto contractReqDto = dto.getContract();
+			contractReqDto.setPropertyId(property.getId());
+			contractStore.create(contractReqDto.toEntity(property, null, agent));
+		}
 		// 응답 객체 리턴
 		return new CreatePropertyResDto(property.getId());
 	}


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 매물 등록 시 계약 정보도 함께 등록하도록 수정
  - 계약은 유형(매매, 전세, 월세) 및 가격 정보만 저장하도록 구현 (계약 가능 상태)

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #182
