### PR TITLE
fix: SSE 알림이 알림 저장 완료 전에 트리거되어 null 또는 오류 해결 #206

### DIFF
--- a/src/main/java/com/househub/backend/domain/inquiry/dto/InquiryDetailResDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiry/dto/InquiryDetailResDto.java
@@ -30,6 +30,7 @@ public class InquiryDetailResDto {
 	@AllArgsConstructor
 	public static class AnswerDto {
 		private Long questionId;
+		private String questionType;
 		private String questionContent;
 		private String answer;
 	}
@@ -43,6 +44,7 @@ public class InquiryDetailResDto {
 		List<AnswerDto> answers = inquiry.getAnswers().stream()
 			.map(a -> AnswerDto.builder()
 				.questionId(a.getQuestion().getId())
+				.questionType(a.getQuestion().getType().name())
 				.questionContent(a.getQuestion().getLabel())
 				.answer(a.getAnswer())
 				.build())

--- a/src/main/java/com/househub/backend/domain/inquiryTemplate/dto/InquiryTemplateSharedResDto.java
+++ b/src/main/java/com/househub/backend/domain/inquiryTemplate/dto/InquiryTemplateSharedResDto.java
@@ -18,6 +18,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class InquiryTemplateSharedResDto {
+	private String type;
 	private String name;
 	private String description;
 	@JsonProperty("isActive")
@@ -26,6 +27,7 @@ public class InquiryTemplateSharedResDto {
 
 	public static InquiryTemplateSharedResDto fromEntity(InquiryTemplate inquiryTemplate, List<Question> questions) {
 		return InquiryTemplateSharedResDto.builder()
+			.type(inquiryTemplate.getType().getKoreanName())
 			.name(inquiryTemplate.getName())
 			.description(inquiryTemplate.getDescription())
 			.active(inquiryTemplate.getActive())

--- a/src/main/java/com/househub/backend/domain/notification/service/EmailService.java
+++ b/src/main/java/com/househub/backend/domain/notification/service/EmailService.java
@@ -1,5 +1,7 @@
 package com.househub.backend.domain.notification.service;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
@@ -49,7 +51,7 @@ public class EmailService {
 	}
 
 	@Async
-	public void send(Notification notification) {
+	public CompletableFuture<Void> send(Notification notification) {
 		SimpleMailMessage message = new SimpleMailMessage();
 		message.setFrom(fromEmail);
 		message.setTo(notification.getReceiver().getEmail()); // 실제 수신자 이메일 주소
@@ -58,8 +60,12 @@ public class EmailService {
 
 		try {
 			mailSender.send(message);
+			return CompletableFuture.completedFuture(null); // 정상 종료
 		} catch (MailException e) {
-			throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED);
+			// 예외 로깅
+			log.error("메일 전송 실패: {}", e.getMessage());
+			// 예외를 CompletableFuture로 반환
+			return CompletableFuture.failedFuture(new BusinessException(ErrorCode.EMAIL_SEND_FAILED));
 		}
 	}
 }

--- a/src/main/java/com/househub/backend/domain/notification/service/impl/NotificationExecutorImpl.java
+++ b/src/main/java/com/househub/backend/domain/notification/service/impl/NotificationExecutorImpl.java
@@ -1,5 +1,7 @@
 package com.househub.backend.domain.notification.service.impl;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.springframework.stereotype.Component;
 
 import com.househub.backend.domain.notification.entity.Notification;
@@ -17,7 +19,7 @@ public class NotificationExecutorImpl implements NotificationExecutor {
 
 	@Override
 	public void send(Notification notification) {
-		emailService.send(notification);
-		sseEmitterService.send(notification);
+		CompletableFuture<Void> emailTask = CompletableFuture.runAsync(() -> emailService.send(notification));
+		emailTask.thenRun(() -> sseEmitterService.send(notification));
 	}
 }


### PR DESCRIPTION
## 📌 PR 목적 및 내용

* 고객 문의 발생 시 알림(Notification) 저장 후, **트랜잭션 커밋 이후에만** 이메일과 SSE를 전송하도록 구조를 개선했습니다.
* 비동기 처리 순서 문제로 인해 발생했던 **SSE 데이터 누락 및 null 전송 문제**를 해결합니다.

## ✏️ 변경 사항

* `NotificationService.sendInquiryNotification()` 내에서 `TransactionSynchronizationManager`를 활용해 **트랜잭션 커밋 이후 알림 전송 로직** 실행하도록 변경
* `NotificationExecutor.send()` 내부 로직 유지 (이메일 비동기, SSE 동기 실행)
* 문제 원인: 알림 저장 전에 SSE가 실행되면서 발생한 **Race Condition** 제거

## 📸 스크린샷 (선택사항)

(해당 사항 없음)

## ✅ 체크리스트

* [x] 코드가 정상적으로 동작하나요?
* [x] 기존 코드와 충돌이 없나요?
* [x] 테스트를 통과했나요?
* [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)

* 관련 이슈: #206
