### PR TITLE
fix: province=서울&city=마포구 에 해당하는 매물 목록 조회 안되는 버그 해결 #223

### DIFF
--- a/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepositoryImpl.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepositoryImpl.java
@@ -157,10 +157,10 @@ public class CrawlingPropertyRepositoryImpl implements CrawlingPropertyRepositor
 			builder.and(crawlingProperty.propertyType.eq(propertyType));
 		}
 		if (province != null) {
-			builder.and(crawlingProperty.province.eq(province));
+			builder.and(crawlingProperty.province.like("%" + province + "%"));
 		}
 		if (city != null) {
-			builder.and(crawlingProperty.city.eq(city));
+			builder.and(crawlingProperty.city.like("%" + city + "%"));
 		}
 		if (dong != null) {
 			builder.and(crawlingProperty.dong.like("%" + dong + "%"));


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- province=서울&city=마포구 에 해당하는 매물 목록 조회 안되는 버그 해결

## ✏️ 변경 사항
- 커밋 참고

## 📸 스크린샷 (선택사항)
- UI 변경이나 기능 추가 시 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #223
