### PR TITLE
seongeun, fix: 공개 매물 태그 검색 시, 1차 필터 부분 수정 #235

### DIFF
--- a/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepositoryImpl.java
+++ b/src/main/java/com/househub/backend/domain/crawlingProperty/repository/CrawlingPropertyRepositoryImpl.java
@@ -205,8 +205,8 @@ public class CrawlingPropertyRepositoryImpl implements CrawlingPropertyRepositor
 			.where(
 				transactionType != null ? crawlingProperty.transactionType.eq(transactionType) : null,
 				propertyType != null ? crawlingProperty.propertyType.eq(propertyType) : null,
-				province != null ? crawlingProperty.province.eq(province) : null,
-				city != null ? crawlingProperty.city.eq(city) : null,
+				province != null ? crawlingProperty.province.contains(province) : null,
+				city != null ? crawlingProperty.city.contains(city) : null,
 				dong != null ? crawlingProperty.dong.contains(dong) : null,
 				minSalePrice != null ? crawlingProperty.salePrice.goe(minSalePrice) : null,
 				maxSalePrice != null ? crawlingProperty.salePrice.loe(maxSalePrice) : null,


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 공개 매물 태그 검색 시, 1차 필터 부분 수정 (eq -> contains)

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #235 
